### PR TITLE
Add btrim to the list of pushed functions and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ SELECT * FROM t1;
 ## 3. Features
 - Support update to foreign table  
 - WHERE clauses are pushdowned  
-- Aggregate function are pushdowned (PostgreSQL 10 only)  
+- Aggregate function are pushdowned
 - Transactions  
 
 ## 4. Limitations

--- a/deparse.c
+++ b/deparse.c
@@ -418,6 +418,7 @@ foreign_expr_walker(Node *node,
 
 				/* these function can be passed to SQLite */
 				if (!(strcmp(opername, "abs") == 0
+					  || strcmp(opername, "btrim") == 0
 					  || strcmp(opername, "length") == 0
 					  || strcmp(opername, "lower") == 0
 					  || strcmp(opername, "ltrim") == 0


### PR DESCRIPTION
There is [code translating](https://github.com/pgspider/sqlite_fdw/blob/master/deparse.c#L1769) `btrim` to `trim` but `btrim` wasn't included in the list of pushable functions. I also forgot to update the README when I added support for aggregate pushdown in 9.6.