### PR TITLE
FIX import schema error: place " OPTIONS (key 'true')" directly after…

### DIFF
--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -1494,15 +1494,15 @@ sqliteImportForeignSchema(ImportForeignSchemaStmt *stmt,
 
 				sqlite_to_pg_type(&buf, type_name);
 
+				/* part of the primary key */
+				if (primary_key)
+					appendStringInfo(&buf, " OPTIONS (key 'true')");
+
 				if (not_null && import_not_null)
 					appendStringInfo(&buf, " NOT NULL");
 
 				if (default_val && import_default)
 					appendStringInfo(&buf, " DEFAULT %s", default_val);
-
-				/* part of the primary key */
-				if (primary_key)
-					appendStringInfo(&buf, " OPTIONS (key 'true')");
 
 			}
 


### PR DESCRIPTION
IMPORT FOREIGN SCHEMA syntax error near OPTIONS(key 'true').
Move OPTIONS before [NOT] NULL and DEFAULT