### PR TITLE
Automated MS Windows builds on AppVeyor CI and PG 13 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Visual Studio related
+.vs/
+x64/
+Debug/
+Release/

--- a/option.c
+++ b/option.c
@@ -64,7 +64,7 @@ static struct SqliteFdwOption valid_options[] =
 	{NULL, InvalidOid}
 };
 
-extern Datum sqlite_fdw_validator(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum sqlite_fdw_validator(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(sqlite_fdw_validator);
 bool

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -90,8 +90,7 @@ enum FdwPathPrivateIndex
 	FdwPathPrivateHasLimit
 };
 
-extern Datum sqlite_fdw_handler(PG_FUNCTION_ARGS);
-extern Datum sqlite_fdw_validator(PG_FUNCTION_ARGS);
+extern PGDLLEXPORT Datum sqlite_fdw_handler(PG_FUNCTION_ARGS);
 
 PG_FUNCTION_INFO_V1(sqlite_fdw_handler);
 

--- a/sqlite_fdw.vcxproj
+++ b/sqlite_fdw.vcxproj
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{C874C880-ED35-4F64-A9EF-D6F6B41935B6}</ProjectGuid>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PlatformToolset>v141</PlatformToolset>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup Label="UserMacros">
+    <pf>$(ProgramFiles)</pf>
+    <pf Condition="$(Platform)=='x64'">$(ProgramW6432)</pf>
+    <pgversion Condition="$(pgversion) == ''">12</pgversion>
+    <pgroot Condition="$(pgroot)==''">$(pf)\PostgreSQL\$(pgversion)</pgroot>
+  </PropertyGroup>
+  <PropertyGroup>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <IncludePath>$(pgroot)\include;$(pgroot)\include\server;$(pgroot)\include\server\port\win32;$(pgroot)\include\server\port\win32_msvc;$(IncludePath)</IncludePath>
+    <LibraryPath>$(pgroot)\lib;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Platform)'=='Win32'">
+    <VcpkgTriplet>x86-windows-static</VcpkgTriplet>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Platform)'=='x64'">
+    <VcpkgTriplet>x64-windows-static</VcpkgTriplet>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <ModuleDefinitionFile>
+      </ModuleDefinitionFile>
+      <AdditionalDependencies>postgres.lib;sqlite3.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>USE_ASSERT_CHECKING</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <StringPooling>true</StringPooling>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+    </ClCompile>
+    <Link>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="sqlite_fdw.c" />
+    <ClCompile Include="option.c" />
+    <ClCompile Include="deparse.c" />
+    <ClCompile Include="connection.c" />
+    <ClCompile Include="sqlite_query.c" />
+    <ClInclude Include="sqlite_fdw.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>


### PR DESCRIPTION
Here are some automated stuff to build the extension against EDB's Windows binaries as well as against PG's git. This addresses already closed #21. Also a couple of minor fixes are included.

I used statically linked sqlite not to carry around sqlite3.dll . Also it is still somewhat tricky to specify a proper platform toolset to match that used by EnterpriseDB's binaries (v140 currently) while using [vcpkg](https://github.com/microsoft/vcpkg) as it picks up the latest (v141 for Visual Studio 2017) available for a given installation. Using static build somewhat alleviates this issue. Perhaps the worker image could be changed to use VS 2015 if we want to rely on VCRUNTIME140.DLL instead of static build.

Note that for AppVeyor to be able to push binary artifacts into GitHub's Releases, one must create a GH token for that. I hope it is not too much to ask. Here is how: https://www.appveyor.com/docs/deployment/github/

