### PR TITLE
Don't use invalidated prepared statement while finalizing

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -397,7 +397,7 @@ sqlitefdw_xact_callback(XactEvent event, void *arg)
 						elog(DEBUG3, "abort transaction");
 
 						/* Finalize all prepared statements */
-						while ((cur = sqlite3_next_stmt(entry->conn, cur)) != NULL)
+						while ((cur = sqlite3_next_stmt(entry->conn, NULL)) != NULL)
 						{
 							sqlite3_finalize(cur);
 						}


### PR DESCRIPTION
This closes #25 Relevant mailing list post http://sqlite.1065341.n5.nabble.com/finalizing-all-statements-before-closing-connection-td46710.html ... though I'm not sure how it reconciles with https://www3.sqlite.org/src/info/f494ed38a8d3fabb as this technique seems to be discouraged.