### PR TITLE
PG 13 compatibility

### DIFF
--- a/deparse.c
+++ b/deparse.c
@@ -15,7 +15,6 @@
 #include "sqlite_fdw.h"
 
 #include "pgtime.h"
-#include "access/heapam.h"
 #include "access/htup_details.h"
 #include "access/sysattr.h"
 #include "catalog/pg_aggregate.h"
@@ -1043,11 +1042,11 @@ sqlite_deparse_select(List *tlist, List **retrieved_attrs, deparse_expr_cxt *con
 		 * Core code already has some lock on each rel being planned, so we
 		 * can use NoLock here.
 		 */
-		Relation	rel = heap_open(rte->relid, NoLock);
+		Relation	rel = table_open(rte->relid, NoLock);
 
 		sqlite_deparse_target_list(buf, root, foreignrel->relid, rel, fpinfo->attrs_used, retrieved_attrs);
 
-		heap_close(rel, NoLock);
+		table_close(rel, NoLock);
 	}
 }
 
@@ -1184,11 +1183,11 @@ deparseFromExprForRel(StringInfo buf, PlannerInfo *root, RelOptInfo *foreignrel,
 		 * Core code already has some lock on each rel being planned, so we
 		 * can use NoLock here.
 		 */
-		Relation	rel = heap_open(rte->relid, NoLock);
+		Relation	rel = table_open(rte->relid, NoLock);
 
 		sqlite_deparse_relation(buf, rel);
 
-		heap_close(rel, NoLock);
+		table_close(rel, NoLock);
 	}
 }
 
@@ -2389,7 +2388,11 @@ deparseAggref(Aggref *node, deparse_expr_cxt *context)
 				first = false;
 
 				/* Add VARIADIC */
+#if PG_VERSION_NUM >= 130000
+				if (use_variadic && lnext(node->args, arg) == NULL)
+#else
 				if (use_variadic && lnext(arg) == NULL)
+#endif
 					appendStringInfoString(buf, "VARIADIC ");
 
 				deparseExpr((Expr *) n, context);

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -1167,7 +1167,7 @@ sqlitePlanForeignModify(PlannerInfo *root,
 	 * Core code already has some lock on each rel being planned, so we can
 	 * use NoLock here.
 	 */
-	rel = heap_open(rte->relid, NoLock);
+	rel = table_open(rte->relid, NoLock);
 
 	foreignTableId = RelationGetRelid(rel);
 	tupdesc = RelationGetDescr(rel);
@@ -1253,7 +1253,7 @@ sqlitePlanForeignModify(PlannerInfo *root,
 			elog(ERROR, "unexpected operation: %d", (int) operation);
 			break;
 	}
-	heap_close(rel, NoLock);
+	table_close(rel, NoLock);
 	return list_make2(makeString(sql.data), targetAttrs);
 }
 

--- a/sqlite_fdw.h
+++ b/sqlite_fdw.h
@@ -20,9 +20,15 @@
 #include "access/table.h"
 #include "utils/float.h"
 #include "optimizer/optimizer.h"
+#if PG_VERSION_NUM >= 130000
+#include "fmgr.h"
+#endif
 #else
 #include "nodes/relation.h"
 #include "optimizer/var.h"
+#include "access/heapam.h"
+#define table_open heap_open
+#define table_close heap_close
 #endif
 
 #include "foreign/foreign.h"


### PR DESCRIPTION
* [table_open/close shall be use in place of heap_open/close](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=f25968c49697db673f6cd2a07b3f7626779f1827)
* [Lists are now implemented as arrays hence lnext needs extra argument](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=1cff1b95ab6ddae32faa3efe0d95a820dbfdc164)
* include fmgr.h  ([probably this commit removed it from rel.h](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=fb3b098fe88441f9531a5169008ea17eac01301f)