### PR TITLE
Improve error messages for unsupported features

### DIFF
--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -1209,11 +1209,14 @@ sqlitePlanForeignModify(PlannerInfo *root,
 	}
 
 	if (plan->returningLists)
-		elog(ERROR, "RETURNING is not supported by this FDW");
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("RETURNING clause is not supported")));
 
 	if (plan->onConflictAction != ONCONFLICT_NONE)
-		elog(ERROR, "not suport ON CONFLICT: %d",
-			 (int) plan->onConflictAction);
+		ereport(ERROR,
+				(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("INSERT with ON CONFLICT clause is not supported")));
 
 	/*
 	 * Add all primary key attribute names to condAttr used in where clause of


### PR DESCRIPTION
This makes a couple of error messages for unsupported features more consistent, and returns an FDW-specific error code (`ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION`) in line with other FDWs.