### PR TITLE
Fix IEEE & bool special values `SELECT` , empty as non-text `NULL` , add message for datatype error

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -43,6 +43,7 @@ typedef struct ConnCacheEntry
 	/* Remaining fields are invalid when conn is NULL: */
 	int			xact_depth;		/* 0 = no xact open, 1 = main xact open, 2 =
 								 * one level of subxact open, etc */
+	bool		updatable;		/* false for readonly connections */
 	bool		keep_connections;	/* setting value of keep_connections
 									 * server option */
 	bool		truncatable;	/* check table can truncate or not */
@@ -193,6 +194,8 @@ sqlite_make_new_connection(ConnCacheEntry *entry, ForeignServer *server)
 	int			rc;
 	char	   *err;
 	ListCell   *lc;
+	int flags = 0;
+	const char *zVfs = NULL;
 
 	Assert(entry->conn == NULL);
 
@@ -201,6 +204,7 @@ sqlite_make_new_connection(ConnCacheEntry *entry, ForeignServer *server)
 	entry->invalidated = false;
 	entry->stmtList = NULL;
 	entry->keep_connections = true;
+	entry->updatable = true;
 	entry->server_hashvalue =
 		GetSysCacheHashValue1(FOREIGNSERVEROID,
 							  ObjectIdGetDatum(server->serverid));
@@ -212,9 +216,12 @@ sqlite_make_new_connection(ConnCacheEntry *entry, ForeignServer *server)
 			dbpath = defGetString(def);
 		else if (strcmp(def->defname, "keep_connections") == 0)
 			entry->keep_connections = defGetBoolean(def);
+		else if (strcmp(def->defname, "updatable") == 0)
+			entry->updatable = defGetBoolean(def);
 	}
 
-	rc = sqlite3_open(dbpath, &entry->conn);
+	flags = flags | (entry->updatable ? SQLITE_OPEN_READWRITE : SQLITE_OPEN_READONLY);
+	rc = sqlite3_open_v2(dbpath, &entry->conn, flags, zVfs);
 	if (rc != SQLITE_OK)
 		ereport(ERROR,
 				(errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),

--- a/option.c
+++ b/option.c
@@ -79,6 +79,10 @@ static struct SqliteFdwOption valid_options[] =
 	{"implicit_bool_type", ForeignServerRelationId},
 	{"implicit_bool_type", ForeignTableRelationId},
 	{"implicit_bool_type", AttributeRelationId},
+	/* empty_as_non_text_null is available on both server, table and column */
+	{"empty_as_non_text_null", ForeignServerRelationId},
+	{"empty_as_non_text_null", ForeignTableRelationId},
+	{"empty_as_non_text_null", AttributeRelationId},
 	/* Sentinel */
 	{NULL, InvalidOid}
 };
@@ -140,7 +144,8 @@ sqlite_fdw_validator(PG_FUNCTION_ARGS)
 			strcmp(def->defname, "keep_connections") == 0 ||
 			strcmp(def->defname, "updatable") == 0 ||
 			strcmp(def->defname, "special_real_values") == 0 ||
-			strcmp(def->defname, "implicit_bool_type") == 0 )
+			strcmp(def->defname, "implicit_bool_type") == 0 ||
+			strcmp(def->defname, "empty_as_non_text_null") == 0 )
 		{
 			defGetBoolean(def);
 		}

--- a/option.c
+++ b/option.c
@@ -56,18 +56,29 @@ struct SqliteFdwOption
  */
 static struct SqliteFdwOption valid_options[] =
 {
-	{"table", ForeignTableRelationId},
 	{"database", ForeignServerRelationId},
+	{"keep_connections", ForeignServerRelationId},
+	{"table", ForeignTableRelationId},
 	{"key", AttributeRelationId},
 	{"column_name", AttributeRelationId},
 	{"column_type", AttributeRelationId},
+	/* updatable is available on both server and table */
+	{"updatable", ForeignServerRelationId},
+	{"updatable", ForeignTableRelationId},
 	/* truncatable is available on both server and table */
 	{"truncatable", ForeignServerRelationId},
 	{"truncatable", ForeignTableRelationId},
-	{"keep_connections", ForeignServerRelationId},
 	/* batch_size is available on both server and table */
 	{"batch_size", ForeignServerRelationId},
 	{"batch_size", ForeignTableRelationId},
+	/* special_real_values is available on both server, table and column */
+	{"special_real_values", ForeignServerRelationId},
+	{"special_real_values", ForeignTableRelationId},
+	{"special_real_values", AttributeRelationId},
+	/* implicit_bool_type is available on both server, table and column */
+	{"implicit_bool_type", ForeignServerRelationId},
+	{"implicit_bool_type", ForeignTableRelationId},
+	{"implicit_bool_type", AttributeRelationId},
 	/* Sentinel */
 	{NULL, InvalidOid}
 };
@@ -126,7 +137,10 @@ sqlite_fdw_validator(PG_FUNCTION_ARGS)
 
 		/* Validate option value */
 		if (strcmp(def->defname, "truncatable") == 0 ||
-			strcmp(def->defname, "keep_connections") == 0)
+			strcmp(def->defname, "keep_connections") == 0 ||
+			strcmp(def->defname, "updatable") == 0 ||
+			strcmp(def->defname, "special_real_values") == 0 ||
+			strcmp(def->defname, "implicit_bool_type") == 0 )
 		{
 			defGetBoolean(def);
 		}

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -1570,7 +1570,7 @@ make_tuple_from_result_row(sqlite3_stmt * stmt,
 	bool		special_real_values = false;
 	bool		implicit_bool_type = false;
 	bool		empty_as_non_text_null = false;
-	Datum		sqlite_coverted;
+	NullableDatum		sqlite_coverted;
 
 	unsigned int rel = 0;	
 	ForeignTable *table;
@@ -1636,10 +1636,12 @@ make_tuple_from_result_row(sqlite3_stmt * stmt,
 												   sqlite_col_type,
 												   special_real_values, implicit_bool_type,
 												   empty_as_non_text_null);
-			if (sqlite_coverted) {
+			if (!sqlite_coverted.isnull) {
 				is_null[attnum] = false;
-				row[attnum] = sqlite_coverted;
+				row[attnum] = sqlite_coverted.value;
 			}
+			else
+				is_null[attnum] = true;
 		}
 		attid++;
 	}

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -1594,9 +1594,6 @@ make_tuple_from_result_row(sqlite3_stmt * stmt,
 			implicit_bool_type = defGetBoolean(def);
 	}
 
-
-
-
 	memset(row, 0, sizeof(Datum) * tupleDescriptor->natts);
 	memset(is_null, true, sizeof(bool) * tupleDescriptor->natts);
 

--- a/sqlite_fdw.h
+++ b/sqlite_fdw.h
@@ -361,7 +361,7 @@ void		sqlite_rel_connection(sqlite3 * conn);
 void		sqlitefdw_report_error(int elevel, sqlite3_stmt * stmt, sqlite3 * conn, const char *sql, int rc);
 void		sqlite_cache_stmt(ForeignServer *server, sqlite3_stmt * *stmt);
 
-Datum		sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, AttInMetadata *attinmeta, int	sqlite_col_type, bool use_special_IEEE_double, bool use_special_bool_value, bool empty_as_non_text_null);
+NullableDatum	sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, AttInMetadata *attinmeta, int	sqlite_col_type, bool use_special_IEEE_double, bool use_special_bool_value, bool empty_as_non_text_null);
 
 void		sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool *isnull);
 extern void sqlite_do_sql_command(sqlite3 * conn, const char *sql, int level, List **busy_connection);

--- a/sqlite_fdw.h
+++ b/sqlite_fdw.h
@@ -361,7 +361,7 @@ void		sqlite_rel_connection(sqlite3 * conn);
 void		sqlitefdw_report_error(int elevel, sqlite3_stmt * stmt, sqlite3 * conn, const char *sql, int rc);
 void		sqlite_cache_stmt(ForeignServer *server, sqlite3_stmt * *stmt);
 
-Datum		sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, AttInMetadata *attinmeta);
+Datum		sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, AttInMetadata *attinmeta, bool use_special_IEEE_double, bool use_special_bool_value);
 
 void		sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool *isnull);
 extern void sqlite_do_sql_command(sqlite3 * conn, const char *sql, int level, List **busy_connection);

--- a/sqlite_fdw.h
+++ b/sqlite_fdw.h
@@ -361,7 +361,7 @@ void		sqlite_rel_connection(sqlite3 * conn);
 void		sqlitefdw_report_error(int elevel, sqlite3_stmt * stmt, sqlite3 * conn, const char *sql, int rc);
 void		sqlite_cache_stmt(ForeignServer *server, sqlite3_stmt * *stmt);
 
-Datum		sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, AttInMetadata *attinmeta, bool use_special_IEEE_double, bool use_special_bool_value);
+Datum		sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, AttInMetadata *attinmeta, int	sqlite_col_type, bool use_special_IEEE_double, bool use_special_bool_value, bool empty_as_non_text_null);
 
 void		sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool *isnull);
 extern void sqlite_do_sql_command(sqlite3 * conn, const char *sql, int level, List **busy_connection);

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -158,7 +158,7 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, A
 			elog(DEBUG3, "sqlite_fdw : a bool literal for \"%s\" = sqlite \"%s\", affinity = \"%s\", value ='%s'", pg_dataTypeName, pg_eqv_affinity, sqlite_affinity, (char*)value_datum);
 		else if (sqlite_type_eqv_to_pg != SQLITE_TEXT && empty_as_non_text_null && sqlite_col_type == SQLITE_TEXT && !strcmp ((char*)value_datum, ""))
 		{			
-			elog(DEBUG3, "sqlite_fdw : empty as non-text null ");
+			elog(DEBUG3, "sqlite_fdw : empty as non-text null in \"%s\" = sqlite \"%s\", affinity = \"%s\"", pg_dataTypeName, pg_eqv_affinity, sqlite_affinity);
 			return 0;
 		} 
 		else

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -113,9 +113,9 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, A
 
 		if (sqlite_type_eqv_to_pg == SQLITE_FLOAT && sqlite_col_type == SQLITE3_TEXT && use_special_IEEE_double)
 		{
-			bool        special_NaN = false;
-			bool        special_pos_infin = false;
-			bool        special_neg_infin = false;
+			bool		special_NaN = false;
+			bool		special_pos_infin = false;
+			bool		special_neg_infin = false;
 			char		*p;
 			char *uc_str;
 			uc_str = (char *) malloc( strlen((char *)value_datum) + 1 );
@@ -328,7 +328,6 @@ sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool
 				ret = sqlite3_bind_int64(stmt, attnum, dat);
 				break;
 			}
-
 		case FLOAT4OID:
 
 			{
@@ -344,7 +343,6 @@ sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool
 				ret = sqlite3_bind_double(stmt, attnum, dat);
 				break;
 			}
-
 		case NUMERICOID:
 			{
 				Datum		valueDatum = DirectFunctionCall1(numeric_float8, value);
@@ -360,7 +358,6 @@ sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool
 				ret = sqlite3_bind_int(stmt, attnum, dat);
 				break;
 			}
-
 		case BPCHAROID:
 		case VARCHAROID:
 		case TEXTOID:
@@ -372,7 +369,7 @@ sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool
 		case DATEOID:
 			{
 				/* Bind as text because SQLite does not have these types */
-				char	   *outputString = NULL;
+				char*		outputString = NULL;
 				Oid			outputFunctionId = InvalidOid;
 				bool		typeVarLength = false;
 
@@ -384,8 +381,8 @@ sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool
 		case BYTEAOID:
 			{
 				int			len;
-				char	   *dat = NULL;
-				char	   *result = DatumGetPointer(value);
+				char*		dat = NULL;
+				char*		result = DatumGetPointer(value);
 
 				if (VARATT_IS_1B(result))
 				{
@@ -400,7 +397,6 @@ sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool
 				ret = sqlite3_bind_blob(stmt, attnum, dat, len, SQLITE_TRANSIENT);
 				break;
 			}
-
 		default:
 			{
 				ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
@@ -412,9 +408,8 @@ sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool
 	if (ret != SQLITE_OK)
 		ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_DATA_TYPE),
 						errmsg("Can't convert constant value to Sqlite: %s",
-							   sqlite3_errmsg(sqlite3_db_handle(stmt))),
+								sqlite3_errmsg(sqlite3_db_handle(stmt))),
 						errhint("Constant value data type: %u", type)));
-
 }
 
 /*
@@ -459,7 +454,7 @@ static const char* sqlite_datatype(int t)
 		case SQLITE_BLOB:
 			return azType[4];
 		case SQLITE_NULL:
-			return azType[5];									
+			return azType[5];
 		default:
 			return azType[0];
 	}

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -114,7 +114,8 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, A
 		}
 		else
 		{
-			elog(ERROR, "SQLite data affinity = \"%s\" disallowed for PostgreSQL type \"%s\" = SQLite \"%s\"", sqlite_affinity, pg_dataTypeName, pg_eqv_affinity);
+			valueDatum = CStringGetDatum((char*) sqlite3_column_text(stmt, attnum));
+			elog(ERROR, "SQLite data affinity = \"%s\" disallowed for PostgreSQL type \"%s\" = SQLite \"%s\", value ='%s'", sqlite_affinity, pg_dataTypeName, pg_eqv_affinity, (char*)valueDatum);
 		}
 	}
 

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -84,9 +84,6 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, A
 	double		special_IEEE_double = 0.0 / 0.0 ; // NaN
 	bool		is_special_bool_value = false;
 	bool		special_bool_value = false;
-	const char * sqlite_affinity;
-	const char * pg_eqv_affinity;
-	const char * pg_dataTypeName;
 
 	/* get the type's output function */
 	tuple = SearchSysCache1(TYPEOID, ObjectIdGetDatum(pgtyp));
@@ -97,18 +94,18 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, A
 	typemod = ((Form_pg_type) GETSTRUCT(tuple))->typtypmod;
 	ReleaseSysCache(tuple);
 
-	/* prepare all metadata for datatypes both in forms for PostgreSQL
-	 * and SQLite, both on int and char* forms
-	 */
 	sqlite_type_eqv_to_pg = sqlite_eqv_from_pgtyp(pgtyp);
 	sqlite_col_type = sqlite3_column_type(stmt, attnum);
 
-	pg_dataTypeName = TypeNameToString(makeTypeNameFromOid(pgtyp, pgtypmod));
-	sqlite_affinity = sqlite_datatype(sqlite_col_type);
-	pg_eqv_affinity = sqlite_datatype(sqlite_type_eqv_to_pg);
-
 	if (sqlite_type_eqv_to_pg != sqlite_col_type && sqlite_col_type == SQLITE3_TEXT)
-	{
+	{	// prepare string for data type and affinities
+		const char * sqlite_affinity;
+		const char * pg_eqv_affinity;
+		const char * pg_dataTypeName;
+		pg_dataTypeName = TypeNameToString(makeTypeNameFromOid(pgtyp, pgtypmod));
+		sqlite_affinity = sqlite_datatype(sqlite_col_type);
+		pg_eqv_affinity = sqlite_datatype(sqlite_type_eqv_to_pg);
+	
 		value_datum = CStringGetDatum((char*) sqlite3_column_text(stmt, attnum));
 
 		if (sqlite_type_eqv_to_pg == SQLITE_FLOAT && sqlite_col_type == SQLITE3_TEXT && use_special_IEEE_double)

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -109,19 +109,13 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int attnum, A
 	if (sqlite_type_eqv_to_pg == SQLITE_BLOB && sqlite_type_eqv_to_pg != value_affinity)
 	{ 
 		if (force_bytea && value_affinity == SQLITE3_TEXT )
-		{
+		{	// Log transformation of text affinity values as bytea or other blob
 			elog(DEBUG2, "sqlite_fdw : \"%s\" affinity transparent converted to \"%s\" = sqlite \"%s\"", sqlite_affinity, pg_dataTypeName, pg_eqv_affinity);
 		}
 		else
 		{
 			elog(ERROR, "SQLite data affinity = \"%s\" disallowed for PostgreSQL type \"%s\" = SQLite \"%s\"", sqlite_affinity, pg_dataTypeName, pg_eqv_affinity);
 		}
-	}
-	// Log transformation of text affinity values as bytea or other blob
-	if (sqlite_type_eqv_to_pg == SQLITE_BLOB && value_affinity == SQLITE3_TEXT && )
-	{
-
-	}
 	}
 
 	// Second check text data converted to any not equal datatype but not to blob


### PR DESCRIPTION
In case of SQLite non-`STRICT` table contains in `real` column valid for PostgreSQL **strings with `text` affinity** such as case insensitive `NaN`, `+Infinity`, `+INF`, `infinity`, `-INF` etc. will be converted to PostgreSQL IEEE special values.
Note: **there is no special IEEE values in SQlite at all**, we just use SQlite as normal input for PostgreSQL `float`-family values regarding to output of `psql` for this special values.
Also added selecting from SQLite `text`-affinity values to PostgreSQL `bool` columns like in [firebird_fdw](https://github.com/ibarwick/firebird_fdw) realisation.