### PR TITLE
Fix no sqlite_fdw functions in pg catalog during CREATE EXTENSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ MODULE_big = sqlite_fdw
 OBJS = connection.o option.o deparse.o sqlite_query.o sqlite_fdw.o
 
 EXTENSION = sqlite_fdw
-DATA = sqlite_fdw--1.0.sql sqlite_fdw--1.0--1.1.sql
+DATA = sqlite_fdw--1.0.sql sqlite_fdw--1.0--1.1.sql sqlite_fdw--1.1.sql
 
 REGRESS = extra/sqlite_fdw_post extra/float4 extra/float8 extra/int4 extra/int8 extra/numeric extra/join extra/limit extra/aggregates extra/prepare extra/select_having extra/select extra/insert extra/update extra/timestamp sqlite_fdw type aggregate selectfunc 
 

--- a/sqlite_fdw--1.1.sql
+++ b/sqlite_fdw--1.1.sql
@@ -1,0 +1,38 @@
+/* contrib/sqlite_fdw/sqlite_fdw--1.1.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION sqlite_fdw" to load this file. \quit
+
+CREATE FUNCTION sqlite_fdw_handler()
+RETURNS fdw_handler
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FUNCTION sqlite_fdw_validator(text[], oid)
+RETURNS void
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+CREATE FOREIGN DATA WRAPPER sqlite_fdw
+  HANDLER sqlite_fdw_handler
+  VALIDATOR sqlite_fdw_validator;
+
+CREATE OR REPLACE FUNCTION sqlite_fdw_version()
+RETURNS pg_catalog.int4
+AS 'MODULE_PATHNAME' LANGUAGE C STRICT;
+
+CREATE FUNCTION sqlite_fdw_get_connections (OUT server_name text,
+    OUT valid boolean)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT PARALLEL RESTRICTED;
+
+CREATE FUNCTION sqlite_fdw_disconnect (text)
+RETURNS bool
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT PARALLEL RESTRICTED;
+
+CREATE FUNCTION sqlite_fdw_disconnect_all ()
+RETURNS bool
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT PARALLEL RESTRICTED;


### PR DESCRIPTION
There were no separate SQL for the last version, hence executed SQL for previous version not contained `sqlite_fdw` user callable functions.
Restored in DDL SQL scripts, de facto function exists is `.so`.