### PR TITLE
Fix failure to escape query parameters in parentheses #62

### DIFF
--- a/deparse.c
+++ b/deparse.c
@@ -2940,6 +2940,9 @@ sqlite_deparse_scalar_array_op_expr(ScalarArrayOpExpr *node, deparse_expr_cxt *c
 							}
 							continue;
 						}
+
+						if (SQL_STR_DOUBLE(ch, true))
+							appendStringInfoChar(buf, ch);
 						appendStringInfoChar(buf, ch);
 					}
 

--- a/expected/11.17/sqlite_fdw.out
+++ b/expected/11.17/sqlite_fdw.out
@@ -1500,6 +1500,56 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 ERROR:  invalid input syntax for type =1, column type =3
+-- issue #62 github
+--Testcase 236:
+INSERT INTO noprimary VALUES (4, 'Test''s');
+--Testcase 237:
+INSERT INTO noprimary VALUES (5, 'Test');
+--Testcase 238:
+SELECT * FROM noprimary;
+ a |   b    
+---+--------
+ 1 | 2
+ 1 | 2
+ 4 | Test's
+ 5 | Test
+(4 rows)
+
+--Testcase 239:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b = 'Test''s';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..7.00 rows=7 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE ((`b` = 'Test''s'))
+(3 rows)
+
+--Testcase 240:
+SELECT * FROM noprimary where b = 'Test''s';
+ a |   b    
+---+--------
+ 4 | Test's
+(1 row)
+
+--Testcase 241:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..14.00 rows=14 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE (`b` IN ('Test''s', 'Test'))
+(3 rows)
+
+--Testcase 242:
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+ a |   b    
+---+--------
+ 4 | Test's
+ 5 | Test
+(2 rows)
+
 -- Executable test case for pushdown CASE expressions (results)
 --Testcase 224:
 CREATE FOREIGN TABLE case_exp(c1 int OPTIONS (key 'true'), c3 text, c6 varchar(10)) SERVER sqlite_svr;

--- a/expected/12.12/sqlite_fdw.out
+++ b/expected/12.12/sqlite_fdw.out
@@ -1500,6 +1500,56 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 ERROR:  invalid input syntax for type =1, column type =3
+-- issue #62 github
+--Testcase 236:
+INSERT INTO noprimary VALUES (4, 'Test''s');
+--Testcase 237:
+INSERT INTO noprimary VALUES (5, 'Test');
+--Testcase 238:
+SELECT * FROM noprimary;
+ a |   b    
+---+--------
+ 1 | 2
+ 1 | 2
+ 4 | Test's
+ 5 | Test
+(4 rows)
+
+--Testcase 239:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b = 'Test''s';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..7.00 rows=7 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE ((`b` = 'Test''s'))
+(3 rows)
+
+--Testcase 240:
+SELECT * FROM noprimary where b = 'Test''s';
+ a |   b    
+---+--------
+ 4 | Test's
+(1 row)
+
+--Testcase 241:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..14.00 rows=14 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE (`b` IN ('Test''s', 'Test'))
+(3 rows)
+
+--Testcase 242:
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+ a |   b    
+---+--------
+ 4 | Test's
+ 5 | Test
+(2 rows)
+
 -- Executable test case for pushdown CASE expressions (results)
 --Testcase 224:
 CREATE FOREIGN TABLE case_exp(c1 int OPTIONS (key 'true'), c3 text, c6 varchar(10)) SERVER sqlite_svr;

--- a/expected/13.8/sqlite_fdw.out
+++ b/expected/13.8/sqlite_fdw.out
@@ -1500,6 +1500,56 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 ERROR:  invalid input syntax for type =1, column type =3
+-- issue #62 github
+--Testcase 236:
+INSERT INTO noprimary VALUES (4, 'Test''s');
+--Testcase 237:
+INSERT INTO noprimary VALUES (5, 'Test');
+--Testcase 238:
+SELECT * FROM noprimary;
+ a |   b    
+---+--------
+ 1 | 2
+ 1 | 2
+ 4 | Test's
+ 5 | Test
+(4 rows)
+
+--Testcase 239:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b = 'Test''s';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..7.00 rows=7 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE ((`b` = 'Test''s'))
+(3 rows)
+
+--Testcase 240:
+SELECT * FROM noprimary where b = 'Test''s';
+ a |   b    
+---+--------
+ 4 | Test's
+(1 row)
+
+--Testcase 241:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..14.00 rows=14 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE (`b` IN ('Test''s', 'Test'))
+(3 rows)
+
+--Testcase 242:
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+ a |   b    
+---+--------
+ 4 | Test's
+ 5 | Test
+(2 rows)
+
 -- Executable test case for pushdown CASE expressions (results)
 --Testcase 224:
 CREATE FOREIGN TABLE case_exp(c1 int OPTIONS (key 'true'), c3 text, c6 varchar(10)) SERVER sqlite_svr;

--- a/expected/14.5/sqlite_fdw.out
+++ b/expected/14.5/sqlite_fdw.out
@@ -1482,6 +1482,56 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 ERROR:  invalid input syntax for type =1, column type =3
+-- issue #62 github
+--Testcase 236:
+INSERT INTO noprimary VALUES (4, 'Test''s');
+--Testcase 237:
+INSERT INTO noprimary VALUES (5, 'Test');
+--Testcase 238:
+SELECT * FROM noprimary;
+ a |   b    
+---+--------
+ 1 | 2
+ 1 | 2
+ 4 | Test's
+ 5 | Test
+(4 rows)
+
+--Testcase 239:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b = 'Test''s';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..7.00 rows=7 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE ((`b` = 'Test''s'))
+(3 rows)
+
+--Testcase 240:
+SELECT * FROM noprimary where b = 'Test''s';
+ a |   b    
+---+--------
+ 4 | Test's
+(1 row)
+
+--Testcase 241:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..14.00 rows=14 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE (`b` IN ('Test''s', 'Test'))
+(3 rows)
+
+--Testcase 242:
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+ a |   b    
+---+--------
+ 4 | Test's
+ 5 | Test
+(2 rows)
+
 -- INSERT/UPDATE whole row with generated column
 --Testcase 216:
 CREATE FOREIGN TABLE grem1_1 (

--- a/expected/15.0/sqlite_fdw.out
+++ b/expected/15.0/sqlite_fdw.out
@@ -1482,6 +1482,56 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 ERROR:  invalid input syntax for type =1, column type =3
+-- issue #62 github
+--Testcase 236:
+INSERT INTO noprimary VALUES (4, 'Test''s');
+--Testcase 237:
+INSERT INTO noprimary VALUES (5, 'Test');
+--Testcase 238:
+SELECT * FROM noprimary;
+ a |   b    
+---+--------
+ 1 | 2
+ 1 | 2
+ 4 | Test's
+ 5 | Test
+(4 rows)
+
+--Testcase 239:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b = 'Test''s';
+                                   QUERY PLAN                                    
+---------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..7.00 rows=7 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE ((`b` = 'Test''s'))
+(3 rows)
+
+--Testcase 240:
+SELECT * FROM noprimary where b = 'Test''s';
+ a |   b    
+---+--------
+ 4 | Test's
+(1 row)
+
+--Testcase 241:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Foreign Scan on public.noprimary  (cost=10.00..14.00 rows=14 width=36)
+   Output: a, b
+   SQLite query: SELECT `a`, `b` FROM main."noprimary" WHERE (`b` IN ('Test''s', 'Test'))
+(3 rows)
+
+--Testcase 242:
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+ a |   b    
+---+--------
+ 4 | Test's
+ 5 | Test
+(2 rows)
+
 -- INSERT/UPDATE whole row with generated column
 --Testcase 216:
 CREATE FOREIGN TABLE grem1_1 (

--- a/sql/11.17/sqlite_fdw.sql
+++ b/sql/11.17/sqlite_fdw.sql
@@ -551,6 +551,26 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 
+-- issue #62 github
+--Testcase 236:
+INSERT INTO noprimary VALUES (4, 'Test''s');
+--Testcase 237:
+INSERT INTO noprimary VALUES (5, 'Test');
+
+--Testcase 238:
+SELECT * FROM noprimary;
+--Testcase 239:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b = 'Test''s';
+--Testcase 240:
+SELECT * FROM noprimary where b = 'Test''s';
+
+--Testcase 241:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+--Testcase 242:
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+
 -- Executable test case for pushdown CASE expressions (results)
 --Testcase 224:
 CREATE FOREIGN TABLE case_exp(c1 int OPTIONS (key 'true'), c3 text, c6 varchar(10)) SERVER sqlite_svr;

--- a/sql/12.12/sqlite_fdw.sql
+++ b/sql/12.12/sqlite_fdw.sql
@@ -551,6 +551,26 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 
+-- issue #62 github
+--Testcase 236:
+INSERT INTO noprimary VALUES (4, 'Test''s');
+--Testcase 237:
+INSERT INTO noprimary VALUES (5, 'Test');
+
+--Testcase 238:
+SELECT * FROM noprimary;
+--Testcase 239:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b = 'Test''s';
+--Testcase 240:
+SELECT * FROM noprimary where b = 'Test''s';
+
+--Testcase 241:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+--Testcase 242:
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+
 -- Executable test case for pushdown CASE expressions (results)
 --Testcase 224:
 CREATE FOREIGN TABLE case_exp(c1 int OPTIONS (key 'true'), c3 text, c6 varchar(10)) SERVER sqlite_svr;

--- a/sql/13.8/sqlite_fdw.sql
+++ b/sql/13.8/sqlite_fdw.sql
@@ -551,6 +551,16 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 
+-- issue #62 github
+--Testcase 236:
+SELECT * FROM noprimary;
+
+--Testcase 237:
+SELECT * FROM noprimary where b = 'Test''s';
+
+--Testcase 238:
+SELECT * FROM noprimary where b in ('Test''s', '2');
+
 -- Executable test case for pushdown CASE expressions (results)
 --Testcase 224:
 CREATE FOREIGN TABLE case_exp(c1 int OPTIONS (key 'true'), c3 text, c6 varchar(10)) SERVER sqlite_svr;

--- a/sql/14.5/sqlite_fdw.sql
+++ b/sql/14.5/sqlite_fdw.sql
@@ -547,6 +547,26 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 
+-- issue #62 github
+--Testcase 236:
+INSERT INTO noprimary VALUES (4, 'Test''s');
+--Testcase 237:
+INSERT INTO noprimary VALUES (5, 'Test');
+
+--Testcase 238:
+SELECT * FROM noprimary;
+--Testcase 239:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b = 'Test''s';
+--Testcase 240:
+SELECT * FROM noprimary where b = 'Test''s';
+
+--Testcase 241:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+--Testcase 242:
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+
 -- INSERT/UPDATE whole row with generated column
 --Testcase 216:
 CREATE FOREIGN TABLE grem1_1 (

--- a/sql/15.0/sqlite_fdw.sql
+++ b/sql/15.0/sqlite_fdw.sql
@@ -547,6 +547,26 @@ ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
 
+-- issue #62 github
+--Testcase 236:
+INSERT INTO noprimary VALUES (4, 'Test''s');
+--Testcase 237:
+INSERT INTO noprimary VALUES (5, 'Test');
+
+--Testcase 238:
+SELECT * FROM noprimary;
+--Testcase 239:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b = 'Test''s';
+--Testcase 240:
+SELECT * FROM noprimary where b = 'Test''s';
+
+--Testcase 241:
+EXPLAIN VERBOSE
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+--Testcase 242:
+SELECT * FROM noprimary where b in ('Test''s', 'Test');
+
 -- INSERT/UPDATE whole row with generated column
 --Testcase 216:
 CREATE FOREIGN TABLE grem1_1 (


### PR DESCRIPTION
Fix error when execute query contains escape parameters in parentheses   
  Example SQL: SELECT * FROM ftbl where title in ('Test''s', 'other tests');