### PR TITLE
Add support for pragma journal_mode and synchronous

### DIFF
--- a/option.c
+++ b/option.c
@@ -61,6 +61,8 @@ static struct SqliteFdwOption valid_options[] =
 	{"key", AttributeRelationId},
 	{"column_name", AttributeRelationId},
 	{"column_type", AttributeRelationId},
+	{"journal_mode", ForeignServerRelationId},
+	{"synchronous", ForeignServerRelationId},
 	/* truncatable is available on both server and table */
 	{"truncatable", ForeignServerRelationId},
 	{"truncatable", ForeignTableRelationId},
@@ -151,6 +153,38 @@ sqlite_fdw_validator(PG_FUNCTION_ARGS)
 						 errmsg("\"%s\" must be an integer value greater than zero",
 								def->defname)));
 		}
+		else if (strcmp(def->defname, "journal_mode") == 0)
+        {
+            char	   *value;
+            value = defGetString(def);
+            if (!(strcmp(value, "delete") == 0
+                || strcmp(value, "truncate") == 0
+                || strcmp(value, "persist") == 0
+                || strcmp(value, "memory") == 0
+                || strcmp(value, "wal") == 0
+                || strcmp(value, "off") == 0)
+            )
+            ereport(ERROR,
+                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                     errmsg("\"%s\" parameter is not valid; accepted values: 'delete', 'truncate', 'persist', "
+                     "'memory', 'wal', 'off'.",
+                            def->defname)));
+        }
+        else if (strcmp(def->defname, "synchronous") == 0)
+        {
+            char	   *value;
+            value = defGetString(def);
+            if (!(strcmp(value, "off") == 0
+                || strcmp(value, "normal") == 0
+                || strcmp(value, "full") == 0
+                || strcmp(value, "extra") == 0)
+            )
+            ereport(ERROR,
+                    (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                     errmsg("\"%s\" parameter is not valid; accepted values: 'off', 'normal', 'full', "
+                     "'extra'.",
+                            def->defname)));
+        }
 	}
 	PG_RETURN_VOID();
 }


### PR DESCRIPTION
### Introduction

Dear maintainers,
I would like to contribute to the project by adding the support to tune the `journal_mode` and `synchronous`  settings.
Such parameters ([https://www.sqlite.org/pragma.html#pragma_journal_mode](https://www.sqlite.org/pragma.html#pragma_journal_mode), [https://www.sqlite.org/pragma.html#pragma_synchronous](https://www.sqlite.org/pragma.html#pragma_synchronous)) control the [rollback journal](https://www.sqlite.org/lockingv3.html#rollback) and some aspects of the syncing process. 
This allows users to find the right balance between robustness against crashes and performances: for example, they can decide to completely disable journaling to improve response times.

### Technical details

Users can tune `journal_mode` and `synchronous` options of the server, selecting the modalities that they want. At present, such changes will be applied only to new connections (`sqlite_make_new_connection`), but if you deem this feature useful, I can add the support to change settings of existing connections.

Accepted values (same ones assumed in the official documentation):

- `journal_mode`: `'delete'`, `'truncate',` `'persist'`, `'memory'`, `'wal'`, `'off'`.
- `synchronous`: `'off'`, `'normal'`, `'full'`, `'extra'`.

### Tests
I have a collection of manual tests to show the correct behaviour of the changes. However, at present I do not know how to integrate them. I would be glad to add them if you could provide information on the following points:

- the exact parameters to run `test.sh`, mentioned in the README.md.
- the exact positions where tests must be added in terms of expected values and results.

Best regards,
Francesco
