### PR TITLE
Prepare C-language infrastructure for ISO:SQL

### DIFF
--- a/deparse.c
+++ b/deparse.c
@@ -2092,6 +2092,7 @@ sqlite_deparse_column_option(int varno, int varattno, PlannerInfo *root, char *o
 void
 sqlite_deparse_string_literal(StringInfo buf, const char *val)
 {
+    // TODO: text input for SQLite is always UTF-8, we need to respect PostgreSQL database encoding
 	const char *valptr;
 
 	appendStringInfoChar(buf, '\'');

--- a/deparse.c
+++ b/deparse.c
@@ -2092,7 +2092,9 @@ sqlite_deparse_column_option(int varno, int varattno, PlannerInfo *root, char *o
 void
 sqlite_deparse_string_literal(StringInfo buf, const char *val)
 {
-    // TODO: text input for SQLite is always UTF-8, we need to respect PostgreSQL database encoding
+	/*
+	 * text input for SQLite is always UTF-8, we need to respect PostgreSQL database encoding
+	 */
 	const char *valptr;
 
 	appendStringInfoChar(buf, '\'');

--- a/deparse.c
+++ b/deparse.c
@@ -2093,6 +2093,7 @@ void
 sqlite_deparse_string_literal(StringInfo buf, const char *val)
 {
 	/*
+	 * TODO
 	 * text input for SQLite is always UTF-8, we need to respect PostgreSQL database encoding
 	 */
 	const char *valptr;
@@ -2176,8 +2177,6 @@ sqlite_deparse_expr(Expr *node, deparse_expr_cxt *context)
 	}
 }
 
-
-
 /*
  * deparse remote UPDATE statement
  *
@@ -2234,7 +2233,6 @@ sqlite_deparse_update(StringInfo buf, PlannerInfo *root,
 		i++;
 	}
 }
-
 
 /*
  * deparse remote UPDATE statement
@@ -2355,7 +2353,6 @@ sqlite_deparse_delete(StringInfo buf, PlannerInfo *root,
 		i++;
 	}
 }
-
 
 /*
  * deparse remote DELETE statement
@@ -3009,7 +3006,6 @@ sqlite_deparse_scalar_array_op_expr(ScalarArrayOpExpr *node, deparse_expr_cxt *c
 	/* Close IN clause */
 	if (useIn)
 		appendStringInfoChar(buf, ')');
-
 }
 
 /*
@@ -3648,7 +3644,6 @@ sqlite_deparse_sort_group_clause(Index ref, List *tlist, bool force_colno, depar
 	return (Node *) expr;
 }
 
-
 /*
  * Returns true if given Var is deparsed as a subquery output column, in
  * which case, *relno and *colno are set to the IDs for the relation and
@@ -3711,7 +3706,6 @@ sqlite_is_subquery_var(Var *node, RelOptInfo *foreignrel, int *relno, int *colno
 		return sqlite_is_subquery_var(node, innerrel, relno, colno);
 	}
 }
-
 
 /*
  * Get the IDs for the relation and column alias to given Var belonging to

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -1579,17 +1579,14 @@ make_tuple_from_result_row(sqlite3_stmt * stmt,
 		sqlite_value_affinity = sqlite3_column_type(stmt, stmt_colid);
 		if ( sqlite_value_affinity != SQLITE_NULL)
 		{
-		    /* Here will be processing of column options about special convert behaviour 
-		    options = GetForeignColumnOptions(rel, attnum_base);
-			foreach(lc_attr, options)
-			{
-				DefElem    *def = (DefElem *) lfirst(lc_attr);
-
-				if (strcmp(def->defname, "...") == 0)
-					...  = defGet...(def);
-			} */
+		    /* TODO: Processing of column options about special convert behaviour 
+		     * options = GetForeignColumnOptions(rel, attnum_base); ... foreach(lc_attr, options)
+			 */
 			
-			int AffinityBehaviourFlags = 0; // Here will be flags about special convert behaviour from options on database, table or column level
+			int AffinityBehaviourFlags = 0;
+			/* TODO
+			 * Flags about special convert behaviour from options on database, table or column level
+			 */
 
             sqlite_coverted = sqlite_convert_to_pg(pgtype, pgtypmod,
     											   stmt, stmt_colid, festate->attinmeta,
@@ -1764,7 +1761,6 @@ sqliteReScanForeignScan(ForeignScanState *node)
 	festate->rowidx = 0;
 }
 
-
 /*
  * sqliteAddForeignUpdateTargets: Add column(s) needed for update/delete on a foreign table,
  * we are using first column as row identification column, so we are adding that into target
@@ -1844,8 +1840,6 @@ sqliteAddForeignUpdateTargets(
 				 errhint("Set the option \"%s\" on the columns that belong to the primary key.", "key")));
 
 }
-
-
 
 static List *
 sqlitePlanForeignModify(PlannerInfo *root,
@@ -1976,7 +1970,6 @@ sqlitePlanForeignModify(PlannerInfo *root,
 	table_close(rel, NoLock);
 	return list_make3(makeString(sql.data), targetAttrs, makeInteger(values_end_len));
 }
-
 
 static void
 sqliteBeginForeignModify(ModifyTableState *mtstate,
@@ -2946,7 +2939,6 @@ sqliteExecForeignDelete(EState *estate,
 	return slot;
 }
 
-
 static void
 sqliteEndForeignModify(EState *estate,
 					   ResultRelInfo *resultRelInfo)
@@ -2960,7 +2952,6 @@ sqliteEndForeignModify(EState *estate,
 		fmstate->stmt = NULL;
 	}
 }
-
 
 static void
 sqliteExplainForeignScan(ForeignScanState *node,
@@ -2977,7 +2968,6 @@ sqliteExplainForeignScan(ForeignScanState *node,
 		ExplainPropertyText("SQLite query", sql, es);
 	}
 }
-
 
 static void
 sqliteExplainForeignModify(ModifyTableState *mtstate,
@@ -3001,8 +2991,6 @@ sqliteExplainForeignModify(ModifyTableState *mtstate,
 #endif
 }
 
-
-
 static bool
 sqliteAnalyzeForeignTable(Relation relation,
 						  AcquireSampleRowsFunc *func,
@@ -3011,7 +2999,6 @@ sqliteAnalyzeForeignTable(Relation relation,
 	elog(DEBUG1, "sqlite_fdw : %s", __func__);
 	return false;
 }
-
 
 /*
  * Import a foreign schema
@@ -3769,7 +3756,6 @@ sqlite_foreign_grouping_ok(PlannerInfo *root, RelOptInfo *grouped_rel)
 	if (ofpinfo->local_conds)
 		return false;
 
-
 	i = 0;
 	foreach(lc, grouping_target->exprs)
 	{
@@ -4067,7 +4053,6 @@ sqlite_add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
 	if (root->hasHavingQual && !parse->groupClause)
 		return;
 
-
 	/* save the input_rel as outerrel in fpinfo */
 	fpinfo->outerrel = input_rel;
 
@@ -4119,7 +4104,6 @@ sqlite_add_foreign_grouping_paths(PlannerInfo *root, RelOptInfo *input_rel,
 	/* Add generated path into grouped_rel by add_path(). */
 	add_path(grouped_rel, (Path *) grouppath);
 }
-
 
 /*
  * sqlite_add_foreign_ordered_paths
@@ -5113,7 +5097,6 @@ sqlite_to_pg_type(StringInfo str, char *type)
 	pfree(type);
 }
 
-
 /*
  * Force assorted GUC parameters to settings that ensure that we'll output
  * data values in a form that is unambiguous to the remote server.
@@ -5395,7 +5378,6 @@ sqlite_create_cursor(ForeignScanState *node)
 	/* Mark the cursor as created, and show no tuples have been retrieved */
 	festate->cursor_exists = true;
 }
-
 
 /*
  * Execute a direct UPDATE/DELETE statement.

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -1572,15 +1572,14 @@ make_tuple_from_result_row(sqlite3_stmt * stmt,
 	{
 		int			attnum = lfirst_int(lc) - 1;
 		Oid			pgtype = TupleDescAttr(tupleDescriptor, attnum)->atttypid;
-		int32		pgtypmod = TupleDescAttr(tupleDescriptor, attnum)->atttypmod;
-		//List	   *options = NULL;
+		int32		pgtypmod = TupleDescAttr(tupleDescriptor, attnum)->atttypmod;		
 		int			sqlite_value_affinity;
 
 		sqlite_value_affinity = sqlite3_column_type(stmt, stmt_colid);
 		if ( sqlite_value_affinity != SQLITE_NULL)
 		{
-		    /* TODO: Processing of column options about special convert behaviour 
-		     * options = GetForeignColumnOptions(rel, attnum_base); ... foreach(lc_attr, options)
+			/* TODO: Processing of column options about special convert behaviour 
+			 * options = GetForeignColumnOptions(rel, attnum_base); ... foreach(lc_attr, options)
 			 */
 			
 			int AffinityBehaviourFlags = 0;
@@ -1588,10 +1587,10 @@ make_tuple_from_result_row(sqlite3_stmt * stmt,
 			 * Flags about special convert behaviour from options on database, table or column level
 			 */
 
-            sqlite_coverted = sqlite_convert_to_pg(pgtype, pgtypmod,
-    											   stmt, stmt_colid, festate->attinmeta,
-    											   attnum, sqlite_value_affinity,
-    											   AffinityBehaviourFlags);
+			sqlite_coverted = sqlite_convert_to_pg(pgtype, pgtypmod,
+												   stmt, stmt_colid, festate->attinmeta,
+												   attnum, sqlite_value_affinity,
+												   AffinityBehaviourFlags);
 			if (!sqlite_coverted.isnull) {
 				is_null[attnum] = false;
 				row[attnum] = sqlite_coverted.value;
@@ -1940,7 +1939,7 @@ sqlitePlanForeignModify(PlannerInfo *root,
 		options = GetForeignColumnOptions(foreignTableId, attrno);
 		foreach(option, options)
 		{
-			DefElem    *def = (DefElem *) lfirst(option);
+			DefElem		*def = (DefElem *) lfirst(option);
 
 			if (IS_KEY_COLUMN(def))
 			{

--- a/sqlite_fdw.h
+++ b/sqlite_fdw.h
@@ -361,7 +361,7 @@ void		sqlite_rel_connection(sqlite3 * conn);
 void		sqlitefdw_report_error(int elevel, sqlite3_stmt * stmt, sqlite3 * conn, const char *sql, int rc);
 void		sqlite_cache_stmt(ForeignServer *server, sqlite3_stmt * *stmt);
 
-Datum		sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_colid, AttInMetadata *attinmeta, AttrNumber attnum);
+NullableDatum sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_colid, AttInMetadata *attinmeta, AttrNumber attnum, int sqlite_value_affinity, int AffinityBehaviourFlags);
 
 void		sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool *isnull);
 extern void sqlite_do_sql_command(sqlite3 * conn, const char *sql, int level, List **busy_connection);

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -21,63 +21,82 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 
+#include "nodes/makefuncs.h"
+#include "catalog/pg_type.h"
+#include "parser/parse_type.h"
+
 static int32
-			sqlite_from_pgtyp(Oid pgtyp);
+			sqlite_affinity_eqv_to_pgtype(Oid pgtyp);
+static const char*
+            sqlite_datatype(int t);
 
 /*
  * convert_sqlite_to_pg: Convert Sqlite data into PostgreSQL's compatible data types
  */
-Datum
-sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_colid, AttInMetadata *attinmeta, AttrNumber attnum)
+NullableDatum
+sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_colid, AttInMetadata *attinmeta, AttrNumber attnum, int sqlite_value_affinity, int AffinityBehaviourFlags)
 {
 	Datum		value_datum = 0;
 	char	   *valstr = NULL;
-	int			col_type = sqlite3_column_type(stmt, stmt_colid);
-	int			sqlite_type = sqlite_from_pgtyp(pgtyp);
+	int			affinity_for_pg_column = sqlite_affinity_eqv_to_pgtype(pgtyp);
+	int         value_byte_size_blob_or_utf8 = sqlite3_column_bytes(stmt, stmt_colid); // Compute always, void text and void BLOB will be special cases
 
-	if (sqlite_type != col_type && col_type == SQLITE3_TEXT)
-		elog(ERROR, "invalid input syntax for type =%d, column type =%d", sqlite_type, col_type);
+	if (affinity_for_pg_column != sqlite_value_affinity && sqlite_value_affinity == SQLITE3_TEXT)
+	{
+	    /* Here will be human readable error message
+        const char    *sqlite_affinity = 0;
+    	const char    *pg_eqv_affinity = 0;
+	    const char    *pg_dataTypeName = 0;
+	    
+	    pg_dataTypeName = TypeNameToString(makeTypeNameFromOid(pgtyp, pgtypmod));
+		sqlite_affinity = sqlite_datatype(sqlite_value_affinity);
+		pg_eqv_affinity = sqlite_datatype(affinity_for_pg_column);
+		
+		value_datum = CStringGetDatum((char*) sqlite3_column_text(stmt, attnum));
+		elog(ERROR, "SQLite data affinity = \"%s\" disallowed for PostgreSQL type \"%s\" = SQLite \"%s\", value ='%s'", sqlite_affinity, pg_dataTypeName, pg_eqv_affinity, (char*)value_datum);
+	    */
+		elog(ERROR, "invalid input syntax for type =%d, column type =%d", affinity_for_pg_column, sqlite_value_affinity);
+	}
 
 	switch (pgtyp)
 	{
 		case BYTEAOID:
 			{
-				int			blobsize = sqlite3_column_bytes(stmt, stmt_colid);
-
-				value_datum = (Datum) palloc0(blobsize + VARHDRSZ);
-				memcpy(VARDATA(value_datum), sqlite3_column_blob(stmt, stmt_colid), blobsize);
-				SET_VARSIZE(value_datum, blobsize + VARHDRSZ);
-				return PointerGetDatum(value_datum);
+				// int			value_byte_size_blob_or_utf = sqlite3_column_bytes(stmt, stmt_colid); // Calculated always for detectind void values
+				value_datum = (Datum) palloc0(value_byte_size_blob_or_utf8 + VARHDRSZ);
+				memcpy(VARDATA(value_datum), sqlite3_column_blob(stmt, stmt_colid), value_byte_size_blob_or_utf8);
+				SET_VARSIZE(value_datum, value_byte_size_blob_or_utf8 + VARHDRSZ);
+				return (struct NullableDatum) { PointerGetDatum(value_datum), false};
 			}
 		case INT2OID:
 			{
 				int			value = sqlite3_column_int(stmt, stmt_colid);
 
-				return Int16GetDatum(value);
+				return (struct NullableDatum) { Int16GetDatum(value), false};
 			}
 		case INT4OID:
 			{
 				int			value = sqlite3_column_int(stmt, stmt_colid);
 
-				return Int32GetDatum(value);
+				return (struct NullableDatum) { Int32GetDatum(value), false};
 			}
 		case INT8OID:
 			{
 				sqlite3_int64 value = sqlite3_column_int64(stmt, stmt_colid);
 
-				return Int64GetDatum(value);
+				return (struct NullableDatum) { Int64GetDatum(value), false};
 			}
 		case FLOAT4OID:
 			{
 				double		value = sqlite3_column_double(stmt, stmt_colid);
 
-				return Float4GetDatum((float4) value);
+				return (struct NullableDatum) { Float4GetDatum((float4) value), false};
 			}
 		case FLOAT8OID:
 			{
 				double		value = sqlite3_column_double(stmt, stmt_colid);
 
-				return Float8GetDatum((float8) value);
+				return (struct NullableDatum) { Float8GetDatum((float8) value), false};
 			}
 		case TIMESTAMPOID:
 		case TIMESTAMPTZOID:
@@ -92,11 +111,12 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_coli
 				 * "regular" process because its already implemented and
 				 * working properly.
 				 */
-				if (col_type == SQLITE_INTEGER || col_type == SQLITE_FLOAT)
+				if (sqlite_value_affinity == SQLITE_INTEGER || sqlite_value_affinity == SQLITE_FLOAT)
 				{
 					double		value = sqlite3_column_double(stmt, stmt_colid);
+					Datum       d = DirectFunctionCall1(float8_timestamptz, Float8GetDatum((float8) value));
 
-					return DirectFunctionCall1(float8_timestamptz, Float8GetDatum((float8) value));
+					return (struct NullableDatum) { d, false};
 				}
 				else
 				{
@@ -111,15 +131,24 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_coli
 				valstr = DatumGetCString(DirectFunctionCall1(float8out, Float8GetDatum((float8) value)));
 				break;
 			}
+		/* some popular datatypes for default algorythm branch
+		case BPCHAROID:
+		case VARCHAROID:
+		case TEXTOID:
+		case JSONOID:
+		case NAMEOID:
+		case TIMEOID: */
 		default:
-			valstr = (char *) sqlite3_column_text(stmt, stmt_colid);
+		    {   // TODO: text output from SQLite is always UTF-8, we need to respect PostgreSQL database encoding
+    			valstr = (char *) sqlite3_column_text(stmt, stmt_colid);
+			}
 	}
 	/* convert string value to appropriate type value */
 	value_datum = InputFunctionCall(&attinmeta->attinfuncs[attnum],
 									valstr,
 									attinmeta->attioparams[attnum],
 									attinmeta->atttypmods[attnum]);
-	return value_datum;
+	return (struct NullableDatum) { value_datum, false};
 }
 
 /*
@@ -184,8 +213,8 @@ sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool
 
 		case NUMERICOID:
 			{
-				Datum		valueDatum = DirectFunctionCall1(numeric_float8, value);
-				float8		dat = DatumGetFloat8(valueDatum);
+				Datum		value_datum = DirectFunctionCall1(numeric_float8, value);
+				float8		dat = DatumGetFloat8(value_datum);
 
 				ret = sqlite3_bind_double(stmt, attnum, dat);
 				break;
@@ -255,10 +284,10 @@ sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool
 }
 
 /*
- * Give SQLite data type from PG type
+ * Give nearest SQLite data affinity for PostgreSQL data type
  */
 static int32
-sqlite_from_pgtyp(Oid type)
+sqlite_affinity_eqv_to_pgtype(Oid type)
 {
 	switch (type)
 	{
@@ -275,5 +304,29 @@ sqlite_from_pgtyp(Oid type)
 			return SQLITE_BLOB;
 		default:
 			return SQLITE3_TEXT;
+	}
+}
+
+/*
+ * Give equivalent string for SQLite data affinity by int from enum
+ * SQLITE_INTEGER etc.
+ */
+static const char* sqlite_datatype(int t)
+{
+	static const char *azType[] = { "?", "integer", "real", "text", "blob", "null" };
+	switch (t)
+	{
+		case SQLITE_INTEGER:
+			return azType[1];
+		case SQLITE_FLOAT:
+			return azType[2];
+		case SQLITE3_TEXT:
+			return azType[3];
+		case SQLITE_BLOB:
+			return azType[4];
+		case SQLITE_NULL:
+			return azType[5];
+		default:
+			return azType[0];
 	}
 }

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -28,7 +28,7 @@
 static int32
 			sqlite_affinity_eqv_to_pgtype(Oid pgtyp);
 static const char*
-            sqlite_datatype(int t);
+			sqlite_datatype(int t);
 
 /*
  * convert_sqlite_to_pg: Convert Sqlite data into PostgreSQL's compatible data types
@@ -39,22 +39,22 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_coli
 	Datum		value_datum = 0;
 	char	   *valstr = NULL;
 	int			affinity_for_pg_column = sqlite_affinity_eqv_to_pgtype(pgtyp);
-	int         value_byte_size_blob_or_utf8 = sqlite3_column_bytes(stmt, stmt_colid); // Compute always, void text and void BLOB will be special cases
+	int		 	value_byte_size_blob_or_utf8 = sqlite3_column_bytes(stmt, stmt_colid); // Compute always, void text and void BLOB will be special cases
 
 	if (affinity_for_pg_column != sqlite_value_affinity && sqlite_value_affinity == SQLITE3_TEXT)
 	{
-	    /* Here will be human readable error message
-        const char    *sqlite_affinity = 0;
-    	const char    *pg_eqv_affinity = 0;
-	    const char    *pg_dataTypeName = 0;
-	    
-	    pg_dataTypeName = TypeNameToString(makeTypeNameFromOid(pgtyp, pgtypmod));
+		/* Here will be human readable error message
+		const char	*sqlite_affinity = 0;
+		const char	*pg_eqv_affinity = 0;
+		const char	*pg_dataTypeName = 0;
+		
+		pg_dataTypeName = TypeNameToString(makeTypeNameFromOid(pgtyp, pgtypmod));
 		sqlite_affinity = sqlite_datatype(sqlite_value_affinity);
 		pg_eqv_affinity = sqlite_datatype(affinity_for_pg_column);
 		
 		value_datum = CStringGetDatum((char*) sqlite3_column_text(stmt, attnum));
 		elog(ERROR, "SQLite data affinity = \"%s\" disallowed for PostgreSQL type \"%s\" = SQLite \"%s\", value ='%s'", sqlite_affinity, pg_dataTypeName, pg_eqv_affinity, (char*)value_datum);
-	    */
+		*/
 		elog(ERROR, "invalid input syntax for type =%d, column type =%d", affinity_for_pg_column, sqlite_value_affinity);
 	}
 
@@ -114,7 +114,7 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_coli
 				if (sqlite_value_affinity == SQLITE_INTEGER || sqlite_value_affinity == SQLITE_FLOAT)
 				{
 					double		value = sqlite3_column_double(stmt, stmt_colid);
-					Datum       d = DirectFunctionCall1(float8_timestamptz, Float8GetDatum((float8) value));
+					Datum	   d = DirectFunctionCall1(float8_timestamptz, Float8GetDatum((float8) value));
 
 					return (struct NullableDatum) { d, false};
 				}
@@ -131,16 +131,19 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_coli
 				valstr = DatumGetCString(DirectFunctionCall1(float8out, Float8GetDatum((float8) value)));
 				break;
 			}
-		/* some popular datatypes for default algorythm branch
-		case BPCHAROID:
-		case VARCHAROID:
-		case TEXTOID:
-		case JSONOID:
-		case NAMEOID:
-		case TIMEOID: */
+	   /* some popular datatypes for default algorythm branch
+		* case BPCHAROID:
+		* case VARCHAROID:
+		* case TEXTOID:
+		* case JSONOID:
+		* case NAMEOID:
+		* case TIMEOID:
+		*/
 		default:
-		    {   // TODO: text output from SQLite is always UTF-8, we need to respect PostgreSQL database encoding
-    			valstr = (char *) sqlite3_column_text(stmt, stmt_colid);
+			{   /*
+				 * TODO: text output from SQLite is always UTF-8, we need to respect PostgreSQL database encoding
+				 */
+				valstr = (char *) sqlite3_column_text(stmt, stmt_colid);
 			}
 	}
 	/* convert string value to appropriate type value */

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -43,18 +43,18 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_coli
 
 	if (affinity_for_pg_column != sqlite_value_affinity && sqlite_value_affinity == SQLITE3_TEXT)
 	{
-		/* Here will be human readable error message
-		const char	*sqlite_affinity = 0;
-		const char	*pg_eqv_affinity = 0;
-		const char	*pg_dataTypeName = 0;
+		/* TODO: human readable error message based on this code
+		 * const char	*sqlite_affinity = 0;
+		 * const char	*pg_eqv_affinity = 0;
+		 * const char	*pg_dataTypeName = 0;
 		
-		pg_dataTypeName = TypeNameToString(makeTypeNameFromOid(pgtyp, pgtypmod));
-		sqlite_affinity = sqlite_datatype(sqlite_value_affinity);
-		pg_eqv_affinity = sqlite_datatype(affinity_for_pg_column);
+		 * pg_dataTypeName = TypeNameToString(makeTypeNameFromOid(pgtyp, pgtypmod));
+		 * sqlite_affinity = sqlite_datatype(sqlite_value_affinity);
+		 * pg_eqv_affinity = sqlite_datatype(affinity_for_pg_column);
 		
-		value_datum = CStringGetDatum((char*) sqlite3_column_text(stmt, attnum));
-		elog(ERROR, "SQLite data affinity = \"%s\" disallowed for PostgreSQL type \"%s\" = SQLite \"%s\", value ='%s'", sqlite_affinity, pg_dataTypeName, pg_eqv_affinity, (char*)value_datum);
-		*/
+		 * value_datum = CStringGetDatum((char*) sqlite3_column_text(stmt, attnum));
+		 * elog(ERROR, "SQLite data affinity = \"%s\" disallowed for PostgreSQL type \"%s\" = SQLite \"%s\", value ='%s'", sqlite_affinity, pg_dataTypeName, pg_eqv_affinity, (char*)value_datum);
+		 */
 		elog(ERROR, "invalid input syntax for type =%d, column type =%d", affinity_for_pg_column, sqlite_value_affinity);
 	}
 
@@ -131,16 +131,16 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_coli
 				valstr = DatumGetCString(DirectFunctionCall1(float8out, Float8GetDatum((float8) value)));
 				break;
 			}
-	   /* some popular datatypes for default algorythm branch
-		* case BPCHAROID:
-		* case VARCHAROID:
-		* case TEXTOID:
-		* case JSONOID:
-		* case NAMEOID:
-		* case TIMEOID:
-		*/
+		/* some popular datatypes for default algorythm branch
+		 * case BPCHAROID:
+		 * case VARCHAROID:
+		 * case TEXTOID:
+		 * case JSONOID:
+		 * case NAMEOID:
+		 * case TIMEOID:
+		 */
 		default:
-			{   /*
+			{	/*
 				 * TODO: text output from SQLite is always UTF-8, we need to respect PostgreSQL database encoding
 				 */
 				valstr = (char *) sqlite3_column_text(stmt, stmt_colid);

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -44,15 +44,6 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_coli
 	if (affinity_for_pg_column != sqlite_value_affinity && sqlite_value_affinity == SQLITE3_TEXT)
 	{
 		/* TODO: human readable error message based on this code
-		 * const char	*sqlite_affinity = 0;
-		 * const char	*pg_eqv_affinity = 0;
-		 * const char	*pg_dataTypeName = 0;
-		
-		 * pg_dataTypeName = TypeNameToString(makeTypeNameFromOid(pgtyp, pgtypmod));
-		 * sqlite_affinity = sqlite_datatype(sqlite_value_affinity);
-		 * pg_eqv_affinity = sqlite_datatype(affinity_for_pg_column);
-		
-		 * value_datum = CStringGetDatum((char*) sqlite3_column_text(stmt, attnum));
 		 * elog(ERROR, "SQLite data affinity = \"%s\" disallowed for PostgreSQL type \"%s\" = SQLite \"%s\", value ='%s'", sqlite_affinity, pg_dataTypeName, pg_eqv_affinity, (char*)value_datum);
 		 */
 		elog(ERROR, "invalid input syntax for type =%d, column type =%d", affinity_for_pg_column, sqlite_value_affinity);
@@ -140,7 +131,8 @@ sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_coli
 		 * case TIMEOID:
 		 */
 		default:
-			{	/*
+			{
+				/*
 				 * TODO: text output from SQLite is always UTF-8, we need to respect PostgreSQL database encoding
 				 */
 				valstr = (char *) sqlite3_column_text(stmt, stmt_colid);


### PR DESCRIPTION
No SQL behaviour changes.

Preparing to implement SQL behaviour from table discussed in https://github.com/pgspider/sqlite_fdw/issues/66#issuecomment-1504830541

This PR include:
* improve naming;
* add function for human readable error message about SQLite data value affinity;
* change return type for `sqlite_convert_to_pg` from `Datum` to `NullableDatum` for future proper `uuid` processing and other special cases such as void `text` affinity in data for `int` column;
* add TODO comments about PostgreSQL database encoding in proper places;
* reduce double calculating for two functions: `sqlite3_column_bytes` and `sqlite3_column_bytes` for the same data value;
* add draft for human readable error message about SQLite data value affinity;
* etc.