### PR TITLE
Prepare included swithes SQLite affinity in pg data type loop

### DIFF
--- a/sql/init_data/init_core.sql
+++ b/sql/init_data/init_core.sql
@@ -42,7 +42,7 @@ INSERT INTO INT2_TBL(f1) VALUES ('  1234 ');
 --Testcase 3:
 INSERT INTO INT2_TBL(f1) VALUES ('    -1234');
 --Testcase 4:
-INSERT INTO INT2_TBL(f1) VALUES ('34.5');
+INSERT INTO INT2_TBL(f1) VALUES ('345');
 -- largest and smallest values
 --Testcase 5:
 INSERT INTO INT2_TBL(f1) VALUES ('32767');


### PR DESCRIPTION
* Prepare C-language infrastructure for ISO:SQL

No SQL behaviour changes.
This PR include:
* `switch`es (SQLite data affinity) in `switch` (PostgreSQL data type)
* add explicit human readable error messages in case of improper combinations of data type and data affinity.