### PR TITLE
Add uuid support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,40 +113,77 @@ make install
 Usage
 -----
 
-## CREATE SERVER options
+### Datatypes
+**WARNING! The table above represents roadmap**, work still in progress. Untill it will be ended please refer real behaviour in non-obvious cases, where there is no ✔ mark.
+
+This table represents `sqlite_fdw` behaviour if in PostgreSQL foreign table column data of some SQLite [affinity](https://www.sqlite.org/datatype3.html) is detected.
+
+* **∅** - no support (runtime error)
+* **V** - transparent transformation
+* **b** - show per-bit form
+* **T** - cast to text in SQLite utf-8 encoding, then to **PostgreSQL text with current encoding of database** and then transparent transformation if applicable
+* **✔** - transparent transformation where PostgreSQL datatype is equal to SQLite affinity
+* **V+** - transparent transformation if appliacable
+* **?** - not described/not tested
+* **-** - transparent transformation is possible for PostgreSQL (always or for some special values), but not implemented in `sqlite_fdw`.
+
+SQLite `NULL` affinity always can be transparent converted for a nullable column in PostgreSQL.
+
+| PostgreSQL   | SQLite <br> INT  | SQLite <br> REAL | SQLite <br> BLOB | SQLite <br> TEXT | SQLite <br> TEXT but <br>empty|SQLite<br>nearest<br>affinity|
+|-------------:|:------------:|:------------:|:------------:|:------------:|:------------:|-------------:|
+|         bool |      V       |       ?      |      T       |      -       |      ∅       | INT          |
+|       bit(n) |      V       |       ∅      |      V       |      ?       |      ∅       | INT          |
+|        bytea |      b       |       b      |      ✔       |      -       |      ?       | BLOB         |
+|         date |      V       |       V      |      T       |      V+      |    `NULL`    | ?            |
+|       float4 |      V+      |       ✔      |      T       |      -       |    `NULL`    | REAL         |
+|       float8 |      V+      |       ✔      |      T       |      -       |    `NULL`    | REAL         |
+|         int2 |      ✔       |       ?      |      T       |      -       |    `NULL`    | INT          |
+|         int4 |      ✔       |       ?      |      T       |      -       |    `NULL`    | INT          |
+|         int8 |      ✔       |       ?      |      T       |      -       |    `NULL`    | INT          |
+|         json |      ?       |       ?      |      T       |      V+      |      ?       | TEXT         |
+|         name |      ?       |       ?      |      T       |      V       |    `NULL`    | TEXT         |
+|      numeric |      V       |       V      |      T       |      ∅       |    `NULL`    | REAL         |
+|         text |      ?       |       ?      |      T       |      ✔       |      V       | TEXT         |
+|         time |      V       |       V      |      T       |      V+      |    `NULL`    | ?            |
+|    timestamp |      V       |       V      |      T       |      V+      |    `NULL`    | ?            |
+|timestamp + tz|      V       |       V      |      T       |      V+      |    `NULL`    | ?            |
+|         uuid |      ∅       |       ∅      |V+<br>(only<br>16 bytes)| V+ |      ∅       | TEXT, BLOB   |
+|      varchar |      ?       |       ?      |      T       |      ✔       |      V       | TEXT         |
+
+### CREATE SERVER options
 
 `sqlite_fdw` accepts the following options via the `CREATE SERVER` command:
 
 - **database** as *string*, **required**
 
   SQLite database path.
-  
+
 - **updatable** as *boolean*, optional, default *true*
 
   This option allow or disallow write operations on SQLite database file.
-    
+
 - **truncatable** as *boolean*, optional, default *true*
 
   Allows foreign tables to be truncated using the `TRUNCATE` command.
-  
+
 - **keep_connections** as *boolean*, optional, default *true*
-  
+
   Allows to keep connections to SQLite while there is no SQL operations between PostgreSQL and SQLite.
-  
+
 - **batch_size** as *integer*, optional, default *1*
 
   Specifies the number of rows which should be inserted in a single `INSERT` operation. This setting can be overridden for individual tables.
-  
-## CREATE USER MAPPING options
+
+### CREATE USER MAPPING options
 
 There is no user or password conceptions in SQLite, hence `sqlite_fdw` no need any `CREATE USER MAPPING` command.
 
 In OS `sqlite_fdw` works as executed code with permissions of user of PostgreSQL server. Usually it is `postgres` OS user. For interacting with SQLite database without access errors ensure this user have follow permissions:
 - read permission on all directories by path to the SQLite database file;
 - read permission on SQLite database file;
-- write permissions both on SQLite database file and *directory it contains* if you need a modification. During `INSERT`, `UPDATE` or `DELETE` in SQLite database, SQLite engine functions makes temporary files with transaction data in the directory near SQLite database file. Hence without write permissions you'll have a message `failed to execute remote SQL: rc=8 attempt to write a readonly database`. 
+- write permissions both on SQLite database file and *directory it contains* if you need a modification. During `INSERT`, `UPDATE` or `DELETE` in SQLite database, SQLite engine functions makes temporary files with transaction data in the directory near SQLite database file. Hence without write permissions you'll have a message `failed to execute remote SQL: rc=8 attempt to write a readonly database`.
 
-## CREATE FOREIGN TABLE options
+### CREATE FOREIGN TABLE options
 
 `sqlite_fdw` accepts the following table-level options via the
 `CREATE FOREIGN TABLE` command:
@@ -156,17 +193,17 @@ In OS `sqlite_fdw` works as executed code with permissions of user of PostgreSQL
   SQLite table name. Use if not equal to name of foreign table in PostgreSQL. Also see about [identifier case handling](#identifier-case-handling).
 
 - **truncatable** as *boolean*, optional, default from the same `CREATE SERVER` option
-  
+
   See `CREATE SERVER` options section for details.
 
 - **batch_size** as *integer*, optional, default from the same `CREATE SERVER` option
 
-  See `CREATE SERVER` options section for details.  
-  
+  See `CREATE SERVER` options section for details.
+
 - **updatable** as *boolean*, optional, default *true*
 
   This option can allow or disallow write operations on a SQLite table independed of the same server option.
-  
+
 `sqlite_fdw` accepts the following column-level options via the
 `CREATE FOREIGN TABLE` command:
 
@@ -176,18 +213,45 @@ In OS `sqlite_fdw` works as executed code with permissions of user of PostgreSQL
 
 - **column_type** as *string*, optional, no default
 
-  Option to convert INT SQLite column (epoch Unix Time) to be treated/visualized as TIMESTAMP in PostgreSQL.
+	Gives preferred SQLite affinity for some PostgreSQL data types can be stored in different ways in SQLite. Default preferred SQLite affinity for this types is `text`.
+	
+  - Use `INT` value for SQLite column (epoch Unix Time) to be treated/visualized as `timestamp` in PostgreSQL.
+  - Use `BLOB` value for SQLite column to be treated/visualized as `uuid` in PostgreSQL.
 
 - **key** as *boolean*, optional, default *false*
 
   Indicates a column as a part of primary key or unique key of SQLite table.
-  
-## IMPORT FOREIGN SCHEMA options
+
+### IMPORT FOREIGN SCHEMA options
 
 `sqlite_fdw` supports [IMPORT FOREIGN SCHEMA](https://www.postgresql.org/docs/current/sql-importforeignschema.html)
-(PostgreSQL 9.5+) and accepts no custom options for this command.
+(PostgreSQL 9.5+) and accepts following options via the `IMPORT FOREIGN SCHEMA` command:
 
-## TRUNCATE support
+- **import_default** as *boolean*, optional, default *false*
+
+  Allow borrowing default values from SQLite table DDL.
+
+- **import_not_null** as *boolean*, optional, default *true*
+
+  Allow borrowing `NULL`/`NOT NULL` constraints from SQLite table DDL.
+
+#### Datatype tranlsation rules for `IMPORT FOREIGN SCHEMA`
+
+| SQLite       | PostgreSQL       |
+|-------------:|:----------------:|
+| int          | bigint           |
+| char         | text             |
+| clob         | text             |
+| text         | text             |
+| blob         | bytea            |
+| real         | double precision |
+| floa         | double precision |
+| doub         | double precision |
+| datetime     | timestamp        |
+| time         | time             |
+| date         | date             |
+
+### TRUNCATE support
 
 `sqlite_fdw` implements the foreign data wrapper `TRUNCATE` API, available
 from PostgreSQL 14.
@@ -218,7 +282,7 @@ functions, `sqlite_fdw` provides the following user-callable utility functions:
 - **sqlite_fdw_version()**;
 Returns standard "version integer" as `major version * 10000 + minor version * 100 + bugfix`.
 ```
-sqlite_fdw_version 
+sqlite_fdw_version
 --------------------
               20300
 ```
@@ -356,7 +420,7 @@ If you want to update tables, please add `OPTIONS (key 'true')` to a primary key
 	  a integer OPTIONS (key 'true'),
 	  b text
 	)
-	SERVER sqlite_server 
+	SERVER sqlite_server
 	OPTIONS (
 	  table 't1_sqlite'
 	);
@@ -432,6 +496,12 @@ Limitations
 - `sqlite_fdw` boolean values support exists only for `bool` columns in foreign table. SQLite documentation recommends to store boolean as value with `integer` [affinity](https://www.sqlite.org/datatype3.html). `NULL` isn't converted, 1 converted to `true`, all other `NOT NULL` values converted to `false`. During `SELECT ... WHERE condition_column` condition converted only to `condition_column`.
 - `sqlite_fdw` don't provides limited support of boolean values if `bool` column in foreign table mapped to SQLite `text` [affinity](https://www.sqlite.org/datatype3.html).
 
+### UUID values
+- `sqlite_fdw` UUID values support exists only for `uuid` columns in foreign table. SQLite documentation recommends to store UUID as value with both `blob` and `text` [affinity](https://www.sqlite.org/datatype3.html). `sqlite_fdw` can read both `text` and `blob` values.
+- Affinity of UUID value in SQLite table determined by `column_type` option of the column
+for `INSERT` and `UPDATE` commands and also for searched UUID value in `WHERE` predicate. This means visible `SELECT uuid_column ... WHERE 1=1` and filtred `SELECT uuid_column ... WHERE uuid_column=''` will get different results. First command gives *all possible* UUID values. Second command will filter *only values of preferred affinity* determined by `column_type` option of the column.
+- Common limitation of PostgreSQL determines we [can read UUID values in many forms](https://www.postgresql.org/docs/15/datatype-uuid.html), but PostgreSQL gives to `sqlite_fdw` always normalized UUID value for `INSERT`, `UPDATE` commands or `WHERE` predicate calculation. This means for SQLite `text` affinity values we can read all possible forms, but new inserted values will be normalized according PostgreSQL rules. Also in `WHERE` predicate calculation will be used only normalized form fo UUID value. Hence `SELECT uuid_column ... WHERE 1=1` and filtred `SELECT uuid_column ... WHERE uuid_column=''` will get different results if there is some not normalized but possible UUID text values.
+
 Tests
 -----
 Test directory have structure as following:
@@ -441,32 +511,32 @@ Test directory have structure as following:
 |   +---11.7
 |   |       filename1.sql
 |   |       filename2.sql
-|   | 
+|   |
 |   +---12.12
 |   |       filename1.sql
 |   |       filename2.sql
-|   | 
-.................  
+|   |
+.................
 |   \---15.0
 |          filename1.sql
 |          filename2.sql
-|          
+|
 \---expected
 |   +---11.7
 |   |       filename1.out
 |   |       filename2.out
-|   | 
+|   |
 |   +---12.12
 |   |       filename1.out
 |   |       filename2.out
-|   | 
-.................  
+|   |
+.................
 |   \---15.0
             filename1.out
             filename2.out
 ```
 The test cases for each version are based on the test of corresponding version of PostgreSQL.
-You can execute test by test.sh directly. 
+You can execute test by test.sh directly.
 The version of PostgreSQL is detected automatically by $(VERSION) variable in Makefile.
 The corresponding sql and expected directory will be used to compare the result. For example, for Postgres 15.0, you can execute "test.sh" directly, and the sql/15.0 and expected/15.0 will be used to compare automatically.
 

--- a/expected/15.0/extra/sqlite_fdw_post.out
+++ b/expected/15.0/extra/sqlite_fdw_post.out
@@ -4954,16 +4954,20 @@ DROP TABLE reind_fdw_parent;
 ALTER FOREIGN TABLE ft1 ALTER COLUMN c8 TYPE int;
 --Testcase 273:
 SELECT * FROM ft1 ftx(x1,x2,x3,x4,x5,x6,x7,x8) WHERE x1 = 1;
-ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer" = SQLite "integer", value = 'foo'
+ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer"
+HINT:  expected SQLite affinity "integer", incorrect value = 'foo'
 --Testcase 274:
 SELECT  ftx.x1,  ft2.c2, ftx.x8 FROM ft1 ftx(x1,x2,x3,x4,x5,x6,x7,x8), ft2 WHERE ftx.x1 = ft2.c1 AND ftx.x1 = 1;
-ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer" = SQLite "integer", value = 'foo'
+ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer"
+HINT:  expected SQLite affinity "integer", incorrect value = 'foo'
 --Testcase 275:
 SELECT  ftx.x1,  ft2.c2, ftx FROM ft1 ftx(x1,x2,x3,x4,x5,x6,x7,x8), ft2 WHERE ftx.x1 = ft2.c1 AND ftx.x1 = 1;
-ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer" = SQLite "integer", value = 'foo'
+ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer"
+HINT:  expected SQLite affinity "integer", incorrect value = 'foo'
 --Testcase 276:
 SELECT sum(c2), array_agg(c8) FROM ft1 GROUP BY c8;
-ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer" = SQLite "integer", value = 'foo'
+ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer"
+HINT:  expected SQLite affinity "integer", incorrect value = 'foo'
 -- ANALYZE ft1; -- ERROR
 -- ===================================================================
 -- local type can be different from remote type in some cases,

--- a/expected/15.0/sqlite_fdw.out
+++ b/expected/15.0/sqlite_fdw.out
@@ -1483,7 +1483,8 @@ SELECT * FROM fts_table; -- should work
 ALTER TABLE fts_table ALTER COLUMN name TYPE int;
 --Testcase 160:
 SELECT * FROM fts_table; -- should fail
-ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer" = SQLite "integer", value = 'this is name'
+ERROR:  SQLite data affinity "text" disallowed for PostgreSQL data type "integer"
+HINT:  expected SQLite affinity "integer", incorrect value = 'this is name'
 -- issue #62 github
 --Testcase 236:
 INSERT INTO noprimary VALUES (4, 'Test''s');

--- a/expected/15.0/type.out
+++ b/expected/15.0/type.out
@@ -499,9 +499,339 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+--Testcase 108:
+DROP FOREIGN TABLE "type_UUID";
+--Testcase 109:
+CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
+--Testcase 110:
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
+--Testcase 111:
+INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+--Testcase 112:
+INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
+--Testcase 113:
+INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
+--Testcase 114:
+INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
+--Testcase 115:
+INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
+--Testcase 116:
+INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 117:
+INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
+--Testcase 118:
+INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
+--Testcase 119:
+INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
+--Testcase 120:
+INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 121:
+INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
+--Testcase 122:
+INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
+--Testcase 123:
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
+--Testcase 124:
+INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
+--Testcase 125:
+INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
+--Testcase 126:
+INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
+--Testcase 127:
+INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
+--Testcase 128:
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
+--Testcase 129:
+INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+--Testcase 130:
+INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
+--Testcase 131:
+INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
+--Testcase 132:
+INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
+--Testcase 133:
+INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
+--Testcase 134:
+INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 135:
+INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
+--Testcase 136:
+INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
+--Testcase 137:
+INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
+--Testcase 138:
+INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
+--Testcase 139:
+INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
+--Testcase 140:
+INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 141:
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
+--Testcase 142:
+INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+--Testcase 143:
+INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
+--Testcase 144:
+INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
+--Testcase 145:
+INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
+--Testcase 146:
+INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
+--Testcase 147:
+INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 148:
+INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
+--Testcase 149:
+INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
+--Testcase 150:
+INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
+--Testcase 151:
+INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
+--Testcase 152:
+INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
+--Testcase 153:
+INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 154:
+CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
+--Testcase 155:
+SELECT * FROM "type_UUID+";
+ i  |                  u                   |  t   | l  
+----+--------------------------------------+------+----
+  1 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+  2 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+  3 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 38
+  4 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 32
+  5 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 39
+  6 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 37
+  7 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+  8 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+  9 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 38
+ 10 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 37
+ 11 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 32
+ 12 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 39
+ 13 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 14 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 15 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 16 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 17 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 18 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 19 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 20 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 23 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 24 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+(40 rows)
+
+--Testcase 156:
+ALTER FOREIGN TABLE "type_UUID+" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
+--Testcase 157:
+SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
+ i  |                  u                   |  t   | l  
+----+--------------------------------------+------+----
+ 13 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 15 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+(8 rows)
+
+--Testcase 158:
+ALTER FOREIGN TABLE "type_UUID+" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
+--Testcase 159:
+SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
+ i  |                  u                   |  t   | l  
+----+--------------------------------------+------+----
+  1 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 17 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 18 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 19 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 20 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+(7 rows)
+
+--Testcase 160:
+SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
+ i  |                  u                   |  t   | l  
+----+--------------------------------------+------+----
+  7 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 23 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 24 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+(7 rows)
+
+--Testcase 161:
+ALTER FOREIGN TABLE "type_UUID+" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
+--Testcase 162:
+SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
+ i  |                  u                   |  t   | l  
+----+--------------------------------------+------+----
+ 14 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 16 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+(8 rows)
+
+--Testcase 163:
+UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}' WHERE "i" = 25;
+--Testcase 164:
+DELETE FROM "type_UUID" WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}';
+--Testcase 165:
+SELECT * FROM "type_UUID+";
+ i  |                  u                   |  t   | l  
+----+--------------------------------------+------+----
+  1 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+  2 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+  3 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 38
+  4 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 32
+  5 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 39
+  6 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 37
+  7 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+  8 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+  9 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 38
+ 10 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 37
+ 11 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 32
+ 12 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 39
+ 13 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 15 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 17 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 18 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 19 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 20 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 23 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 24 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+(32 rows)
+
+--Testcase 166:
+ALTER FOREIGN TABLE "type_UUID+" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
+--Testcase 167:
+DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
+--Testcase 168:
+SELECT * FROM "type_UUID+";
+ i  |                  u                   |  t   | l  
+----+--------------------------------------+------+----
+  1 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+  2 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+  3 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 38
+  4 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 32
+  5 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 39
+  6 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 37
+  7 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+  8 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+  9 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 38
+ 10 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 37
+ 11 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 32
+ 12 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 39
+ 17 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 18 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 19 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 20 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 23 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 24 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+(24 rows)
+
+--Testcase 169:
+UPDATE "type_UUID" SET "i" = "i" + 40 WHERE "u" = 'a0eebc999c0b4ef8bb6d6bb9bd380a11';
+--Testcase 170:
+SELECT * FROM "type_UUID+";
+ i  |                  u                   |  t   | l  
+----+--------------------------------------+------+----
+  1 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+  2 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+  3 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 38
+  4 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 32
+  5 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 39
+  6 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 37
+  7 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+  8 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+  9 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 38
+ 10 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 37
+ 11 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 32
+ 12 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 39
+ 17 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 18 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 19 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 20 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 23 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 24 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+(24 rows)
+
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
+--Testcase 171:
+INSERT INTO "type_UUID" ("i", "u") VALUES (41, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
+--Testcase 172:
+INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
+--Testcase 173:
+INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a1', 'hex'));
+ERROR:  invalid hexadecimal data: odd number of digits
+--Testcase 174:
+SELECT * FROM "type_UUID+" WHERE "i" = 41;
+ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
+HINT:  incorrect value is 17 bytes length
+--Testcase 175:
+SELECT * FROM "type_UUID+" WHERE "i" = 42;
+ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
+HINT:  incorrect value is 15 bytes length
+--Testcase 176:
+SELECT * FROM "type_UUID+" WHERE "i" = 43;
+ i | u | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;
-NOTICE:  drop cascades to 42 other objects
+NOTICE:  drop cascades to 44 other objects
 DETAIL:  drop cascades to server sqlite_svr
 drop cascades to foreign table department
 drop cascades to foreign table employee
@@ -543,4 +873,6 @@ drop cascades to foreign table "RO_RW_test"
 drop cascades to foreign table "Unicode data"
 drop cascades to foreign table type_json
 drop cascades to foreign table "type_BOOLEAN"
+drop cascades to foreign table "type_UUID"
+drop cascades to foreign table "type_UUID+"
 drop cascades to server sqlite2

--- a/sql/15.0/type.sql
+++ b/sql/15.0/type.sql
@@ -266,5 +266,146 @@ SELECT * FROM "type_DOUBLE"; -- OK
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
 
+--Testcase 108:
+DROP FOREIGN TABLE "type_UUID";
+--Testcase 109:
+CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
+--Testcase 110:
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
+--Testcase 111:
+INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+--Testcase 112:
+INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
+--Testcase 113:
+INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
+--Testcase 114:
+INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
+--Testcase 115:
+INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
+--Testcase 116:
+INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 117:
+INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
+--Testcase 118:
+INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
+--Testcase 119:
+INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
+--Testcase 120:
+INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 121:
+INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
+--Testcase 122:
+INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
+--Testcase 123:
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
+--Testcase 124:
+INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
+--Testcase 125:
+INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
+--Testcase 126:
+INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
+--Testcase 127:
+INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
+--Testcase 128:
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
+--Testcase 129:
+INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+--Testcase 130:
+INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
+--Testcase 131:
+INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
+--Testcase 132:
+INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
+--Testcase 133:
+INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
+--Testcase 134:
+INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 135:
+INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
+--Testcase 136:
+INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
+--Testcase 137:
+INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
+--Testcase 138:
+INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
+--Testcase 139:
+INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
+--Testcase 140:
+INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 141:
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
+--Testcase 142:
+INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+--Testcase 143:
+INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
+--Testcase 144:
+INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
+--Testcase 145:
+INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
+--Testcase 146:
+INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
+--Testcase 147:
+INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 148:
+INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
+--Testcase 149:
+INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
+--Testcase 150:
+INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
+--Testcase 151:
+INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
+--Testcase 152:
+INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
+--Testcase 153:
+INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 154:
+CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
+--Testcase 155:
+SELECT * FROM "type_UUID+";
+
+--Testcase 156:
+ALTER FOREIGN TABLE "type_UUID+" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
+--Testcase 157:
+SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
+--Testcase 158:
+ALTER FOREIGN TABLE "type_UUID+" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
+--Testcase 159:
+SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
+--Testcase 160:
+SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
+--Testcase 161:
+ALTER FOREIGN TABLE "type_UUID+" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
+--Testcase 162:
+SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
+--Testcase 163:
+UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}' WHERE "i" = 25;
+--Testcase 164:
+DELETE FROM "type_UUID" WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}';
+--Testcase 165:
+SELECT * FROM "type_UUID+";
+--Testcase 166:
+ALTER FOREIGN TABLE "type_UUID+" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
+--Testcase 167:
+DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
+--Testcase 168:
+SELECT * FROM "type_UUID+";
+--Testcase 169:
+UPDATE "type_UUID" SET "i" = "i" + 40 WHERE "u" = 'a0eebc999c0b4ef8bb6d6bb9bd380a11';
+--Testcase 170:
+SELECT * FROM "type_UUID+";
+ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
+--Testcase 171:
+INSERT INTO "type_UUID" ("i", "u") VALUES (41, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
+--Testcase 172:
+INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
+--Testcase 173:
+INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a1', 'hex'));
+--Testcase 174:
+SELECT * FROM "type_UUID+" WHERE "i" = 41;
+--Testcase 175:
+SELECT * FROM "type_UUID+" WHERE "i" = 42;
+--Testcase 176:
+SELECT * FROM "type_UUID+" WHERE "i" = 43;
+
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/init_data/init.sql
+++ b/sql/init_data/init.sql
@@ -33,6 +33,8 @@ CREATE TABLE "type_TIMESTAMP" (col timestamp primary key, b timestamp);--, c dat
 CREATE TABLE "type_BLOB" (col blob primary key);
 CREATE TABLE "type_DATE" (col date primary key);
 CREATE TABLE "type_TIME" (col time primary key);
+CREATE TABLE "type_UUID" (i int, u uuid);
+CREATE VIEW  "type_UUID+" AS SELECT *, typeof("u") t, length("u") l FROM "type_UUID";
 CREATE TABLE BitT (p integer primary key, a BIT(3), b BIT VARYING(5));
 CREATE TABLE notype (a);
 CREATE TABLE typetest (i integer, v varchar(10) , c char(10), t text, d datetime, ti timestamp);

--- a/sql/init_data/init_core.sql
+++ b/sql/init_data/init_core.sql
@@ -42,7 +42,7 @@ INSERT INTO INT2_TBL(f1) VALUES ('  1234 ');
 --Testcase 3:
 INSERT INTO INT2_TBL(f1) VALUES ('    -1234');
 --Testcase 4:
-INSERT INTO INT2_TBL(f1) VALUES ('34.5');
+INSERT INTO INT2_TBL(f1) VALUES ('345');
 -- largest and smallest values
 --Testcase 5:
 INSERT INTO INT2_TBL(f1) VALUES ('32767');

--- a/sqlite_fdw.h
+++ b/sqlite_fdw.h
@@ -375,6 +375,6 @@ void		sqlite_cache_stmt(ForeignServer *server, sqlite3_stmt * *stmt);
 
 NullableDatum sqlite_convert_to_pg(Oid pgtyp, int pgtypmod, sqlite3_stmt * stmt, int stmt_colid, AttInMetadata *attinmeta, AttrNumber attnum, int sqlite_value_affinity, int AffinityBehaviourFlags);
 
-void		sqlite_bind_sql_var(Oid type, int attnum, Datum value, sqlite3_stmt * stmt, bool *isnull);
+void		sqlite_bind_sql_var(Oid type, int pgtypmod, int attnum, Datum value, sqlite3_stmt * stmt, bool *isnull, Oid relid);
 extern void sqlite_do_sql_command(sqlite3 * conn, const char *sql, int level, List **busy_connection);
 #endif							/* SQLITE_FDW_H */


### PR DESCRIPTION
This PR include:
* `switch`es (SQLite data affinity) in `switch` (PostgreSQL data type)
* added and improved explicit human readable error messages in case of improper combinations of data type and data affinity.
* tests for UUID values support
* `README.md` description about UUID support and limitations
* `README.md` description of undocumented `IMPORT FOREIGN SCHEMA` options
* `README.md` description of datatype translation rules for `IMPORT FOREIGN SCHEMA`
* improved human readable message about impossible value for binding
* UUID C functions from [unofficial and recommended SQLite extension](https://sqlite.org/src/file/ext/misc/uuid.c) with license note *The author disclaims copyright to this source code*.