### PR TITLE
Add multiversional testing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@
 
 # Log files
 log/
+make_check.out
 
 # Debug files
 *.dSYM/
@@ -59,3 +60,6 @@ dkms.conf
 x64/
 Debug/
 Release/
+
+#Getting scripts for multiversional testing environment
+testing

--- a/README.md
+++ b/README.md
@@ -525,37 +525,164 @@ for `INSERT` and `UPDATE` commands.
 
 Tests
 -----
-Test directory have structure as following:
 
-```sql
-+---sql
-|   +---12.15
-|   |       filename1.sql
-|   |       filename2.sql
-|   |
-|   +---13.11
-|   |       filename1.sql
-|   |       filename2.sql
-|   |
-.................
-|   \---15.3
-|          filename1.sql
-|          filename2.sql
-|
-\---expected
-|   +---12.15
-|   |       filename1.out
-|   |       filename2.out
-|   |
-|   +---13.11
-|   |       filename1.out
-|   |       filename2.out
-|   |
-.................
-|   \---15.3
-            filename1.out
-            filename2.out
+To get multiversional testing PosgtreSQL environment select `cd` or make `mkdir`
+special directory and just execute inside
+```bash
+git clone 'git@github.com:pgspider/sqlite_fdw.git';
+cd sqlite_fdw;
+testing/get_environment.sh;
 ```
+This will run long downloading, configuring, compile and testing process for all
+availlable PostgreSQL versions for this FDW. Note `testing/get_environment.sh` file and `testing` directory will be purged, the scripts will be moved. If you will have no errors, you can test your own changes.
+
+After this long getting process  will be endded the following scripts will be availlable:
+* `../getmvpgenv.sh` - get (based on `git clone`) or refresh (based on `git pull`), configure, compile and test all PostgreSQL source code versions. First parameter - name of FDW directory, e. g. `sqlite_fdw`. Second parameter - address of multiversional source codes in `..` directory (e. g. from `sqlite_fdw`), default 'PostgreSQL source'.
+* `../mulver_test.sh` - do multiversional testing with existed in PostgreSQL sources code of tested fdw. First parameter - name of FDW directory for testing, e. g. `sqlite_fdw`, default 'PostgreSQL source'. Second parameter - address of multiversional source codes in `..` directory (e. g. from `sqlite_fdw`). Thitd parameter - number of tested version (e. g. `12_15`), otherewise for all.
+* `../new_mulver_cycle.sh`- do multiversional testing with code refreshed from your tested directory. First parameter - name of FDW directory for testing, e. g. `sqlite_fdw`. Second parameter - address of multiversional source codes in `..` directory (e. g. from `sqlite_fdw`), default 'PostgreSQL source'. Thitd parameter - number of tested version (e. g. `12_15`), otherewise for all.
+
+After script executing multiversional testing environment directory tree can be look like this. You can have near some directories for testing of the FDW. Just always use needed name as first parameter in scripts.
+
+```
+├── YOUR_TESTING_FDW_SOURCE_CODE_DIRECTORY
+├── OTHER_TESTING_FDW_SOURCE_CODE_DIRECTORY
+├── OTHER_BRANCH_TESTING_FDW_SOURCE_CODE_DIRECTORY
+├── get_environment.sh
+├── getmvpgenv.sh
+├── git sqlite_fdw
+├── mulver_test.sh
+├── new_mulver_cycle.sh
+├── PostgreSQL source # here are links to all results directories and diff files
+│   ├── 12_15_regr.diff -> REL_12_15/postgresql/contrib/sqlite_fdw/regression.diffs
+│   ├── 12_15_results -> REL_12_15/postgresql/contrib/sqlite_fdw/results/12.15
+│   ├── 13_11_regr.diff -> REL_13_11/postgresql/contrib/sqlite_fdw/regression.diffs
+│   ├── 13_11_results -> REL_13_11/postgresql/contrib/sqlite_fdw/results/13.11
+│   ├── 14_8_regr.diff -> REL_14_8/postgresql/contrib/sqlite_fdw/regression.diffs
+│   ├── 14_8_results -> REL_14_8/postgresql/contrib/sqlite_fdw/results/14.8
+│   ├── 15_3_regr.diff -> REL_15_3/postgresql/contrib/sqlite_fdw/regression.diffs
+│   ├── 15_3_results -> REL_15_3/postgresql/contrib/sqlite_fdw/results/15.3
+│   ├── 16_0_regr.diff -> REL_16_0/postgresql/contrib/sqlite_fdw/regression.diffs
+│   ├── 16_0_results -> REL_16_0/postgresql/contrib/sqlite_fdw/results/16.0
+│   ├── REL_12_15
+│   │   └── postgresql
+│   │       ├── aclocal.m4
+│   │       ├── config
+│   │       │   ├── ac_func_accept_argtypes.m4
+..............................
+│   │       ├── contrib
+│   │       │   ├── adminpack
+│   │       │   │   └── ............
+.....................................
+│   │       │   ├── sqlite_fdw
+│   │       │   │   └── ............
+│   │       │   │   
+.....................................
+
+│   ├── REL_13_11
+│   │   └── postgresql
+│   │       └── ............
+│   ├── REL_14_8
+│   │   └── postgresql
+│   │       └── ............
+.....................................
+```
+
+Test directory in the FDW source code directory have structure as following:
+
+```
+├── sql
+│   ├── 12.15
+│   │   ├── aggregate.sql
+│   │   ├── extra
+│   │   │   ├── aggregates.sql
+│   │   │   ├── encodings.sql
+│   │   │   ├── float4.sql
+│   │   │   ├── float8.sql
+│   │   │   ├── insert.sql
+│   │   │   ├── int4.sql
+│   │   │   ├── int8.sql
+│   │   │   ├── join.sql
+│   │   │   ├── limit.sql
+│   │   │   ├── numeric.sql
+│   │   │   ├── prepare.sql
+│   │   │   ├── select_having.sql
+│   │   │   ├── select.sql
+│   │   │   ├── sqlite_fdw_post.sql
+│   │   │   ├── timestamp.sql
+│   │   │   └── update.sql
+│   │   ├── selectfunc.sql
+│   │   ├── sqlite_fdw.sql
+│   │   └── type.sql
+│   ├── 13.11
+│   │   ├── ..............
+..............................
+│   │   └── type.sql
+│   ├── 14.8
+│   │   ├── ..............
+│   │   └── ..............
+│   ├── 15.3
+│   │   ├── ..............
+│   │   └── ..............
+│   ├── 16.0
+│   │   ├── ..............
+│   │   └── ..............
+│   └── init_data
+│       ├── agg.data
+│       ├── datetimes.data
+│       ├── init_core.sql
+│       ├── init_post.sql
+│       ├── init_selectfunc.sql
+│       ├── init.sql
+│       ├── onek.data
+│       ├── person.data
+│       ├── streets.data
+│       ├── student.data
+│       └── tenk.data
+└── expected
+    ├── 12.15
+    │   ├── aggregate.out
+    │   ├── extra
+    │   │   ├── aggregates.out
+    │   │   ├── encodings.out
+    │   │   ├── float4.out
+    │   │   ├── float8.out
+    │   │   ├── insert.out
+    │   │   ├── int4.out
+    │   │   ├── int8.out
+    │   │   ├── join.out
+    │   │   ├── limit.out
+    │   │   ├── numeric.out
+    │   │   ├── prepare.out
+    │   │   ├── select_having.out
+    │   │   ├── select.out
+    │   │   ├── sqlite_fdw_post.out
+    │   │   ├── timestamp.out
+    │   │   └── update.out
+    │   ├── selectfunc.out
+    │   ├── sqlite_fdw.out
+    │   └── type.out
+    ├── 13.11
+    │   ├── aggregate.out
+    │   ├── extra
+    │   │   ├── aggregates.out
+    │   │   ├── .............
+    │   │   ├── .............
+.................................
+    │   │   └── update.out
+    │   ├── selectfunc.out
+    │   ├── sqlite_fdw.out
+    │   └── type.out
+    ├── 14.8
+    │   ├── ..............
+    │   └── ..............
+    ├── 15.3
+    │   ├── ..............
+    │   └── ..............
+    └── 16.0
+        ├── ..............
+        └── ..............
+```
+
 The test cases for each version are based on the test of corresponding version of PostgreSQL.
 You can execute test by test.sh directly.
 The version of PostgreSQL is detected automatically by $(VERSION) variable in Makefile.

--- a/testing/get_environment.sh
+++ b/testing/get_environment.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+f=$(readlink -f "$0");
+f=$(dirname "$f");
+f=$(readlink -f "$f/..");
+fdwname=$(basename "$f");
+echo "-------------------------------------------------------------------------------
+Multiversional testing environment will be
+- downloaded from official PostgreSQL git URLs,
+- compiled,
+- tested against internal regress tests
+Mainstream $fdwname version will be also
+- downloadaed,
+- compiled against all available PostgreSQL versions,
+- tested with all available PostgreSQL versions
+
+This need
+- 1.2+ Gb of disk space,
+- not less than 30 minutes and
+- 1+ Gb of network traffic.
+
+* Please ensure your OS have needed packages for PostgreSQL source code compilation
+See https://wiki.postgresql.org/wiki/Compile_and_Install_from_source_code
+
+* Please ensure also you have got special environment for $fdwname
+
+Press Ctrl+C to interrupt this execution, otherwise press any key";
+read x;
+fn=$(readlink -f "$0");
+dir=$(dirname "$fn");
+rm -v "$fn";
+dest="$dir/../..";
+mv -v "$dir"/*.sh "$dest";
+cd "$dest";
+rmdir -v "$dir/../testing";
+echo -n "Testing multiversional environment getting is started, base directory: ";
+pwd;
+."/getmvpgenv.sh" "$fdwname" "PostgreSQL source";
+# ."/getmvpgenv.sh" "$fdwname" "🐘"; # also tested
+# ."/getmvpgenv.sh" "$fdwname" "🐢"; # also tested, in Japan this is PostgreSQL mascot

--- a/testing/getmvpgenv.sh
+++ b/testing/getmvpgenv.sh
@@ -21,31 +21,35 @@ echo "$ver";
 
 # Get or pull (update) individual PostgreSQL source trees for different versions.
 echo "$ver" | while read ver_curs; do
-    [ ! -d "REL_$ver_curs" ] && mkdir "REL_$ver_curs";
-    cd "REL_$ver_curs";
-    git clone https://git.postgresql.org/git/postgresql.git -b "REL_$ver_curs" || ( cd postgresql; git pull https://git.postgresql.org/git/postgresql.git "REL_$ver_curs"; cd ..;);
-    cd ..;
+	[ ! -d "REL_$ver_curs" ] && mkdir "REL_$ver_curs";
+	(
+ 		cd "REL_$ver_curs";
+		git clone https://git.postgresql.org/git/postgresql.git -b "REL_$ver_curs" || ( cd postgresql; git pull https://git.postgresql.org/git/postgresql.git "REL_$ver_curs"; cd ..;);
+	)
 done;
 
 # Configure PostgreSQL sources
 echo "$ver" | while read ver_curs; do
-	cd "REL_$ver_curs/postgresql";
-	./configure;
-	cd ../..;
+	(
+		cd "REL_$ver_curs/postgresql";
+		./configure;
+	)
 done;
 
 # Make PostgreSQL sources
 echo "$ver" | while read ver_curs; do
-	cd "REL_$ver_curs/postgresql";
-	make;
-	cd ../..;
+	(
+		cd "REL_$ver_curs/postgresql";
+		make;
+	)
 done;
 
 # Run internal checks for PostgreSQL. 
 echo "$ver" | while read ver_curs; do
-	cd "REL_$ver_curs/postgresql";
-	make check;
-	cd ../..;
+	(
+		cd "REL_$ver_curs/postgresql";
+		make check;
+	)
 done;
 
 echo "Beginned at $d0";

--- a/testing/getmvpgenv.sh
+++ b/testing/getmvpgenv.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+[ "$1" == "" ] && exit;
+fdwname="$1";
+[ "$2" == "" ] && pg_multver_src_dir='PostgreSQL source' || pg_multver_src_dir="$2";
+baseadr=$(readlink -f "$0");
+baseadr=$(dirname "$baseadr");
+pg_multver_src_dir0="$pg_multver_src_dir"
+pg_multver_src_dir="$baseadr/$pg_multver_src_dir";
+[ ! -d "$pg_multver_src_dir" ] && (mkdir "$pg_multver_src_dir");
+
+d0=$(date);
+echo "$d0";
+
+cd "$pg_multver_src_dir";
+# Clone original $fdwname.
+[ ! -d "${fdwname}_base" ] && git clone "https://github.com/pgspider/$fdwname" "${fdwname}_base" || (cd "${fdwname}_base"; git pull; cd ..;);
+
+# Get and read list of PostgreSQL versions.
+ver=$(ls -1 "../$fdwname/expected/" | tr '.' '_');
+echo "$ver";
+
+# Get or pull (update) individual PostgreSQL source trees for different versions.
+echo "$ver" | while read ver_curs; do
+    [ ! -d "REL_$ver_curs" ] && mkdir "REL_$ver_curs";
+    cd "REL_$ver_curs";
+    git clone https://git.postgresql.org/git/postgresql.git -b "REL_$ver_curs" || ( cd postgresql; git pull https://git.postgresql.org/git/postgresql.git "REL_$ver_curs"; cd ..;);
+    cd ..;
+done;
+
+# Configure PostgreSQL sources
+echo "$ver" | while read ver_curs; do
+	cd "REL_$ver_curs/postgresql";
+	./configure;
+	cd ../..;
+done;
+
+# Make PostgreSQL sources
+echo "$ver" | while read ver_curs; do
+	cd "REL_$ver_curs/postgresql";
+	make;
+	cd ../..;
+done;
+
+# Run internal checks for PostgreSQL. 
+echo "$ver" | while read ver_curs; do
+	cd "REL_$ver_curs/postgresql";
+	make check;
+	cd ../..;
+done;
+
+echo "Beginned at $d0";
+echo -n "PostgreSQL compiled and tested at";
+date;
+
+# Copy generic $fdwname to contrib directory of all PostgreSQL versions.
+echo "$ver" | while read ver_curs; do
+	basedir="REL_$ver_curs/postgresql/contrib/$fdwname";
+	[ -d "$basedir" ] && rm -r -f "$basedir";
+	cp -r "${fdwname}_base" "$basedir";
+done;
+
+cd ..;
+
+"$baseadr/mulver_test.sh" "$fdwname" "$pg_multver_src_dir0";
+
+echo "Beginned at $d0";
+echo -n "Multiversional testing environment for $fdwname and mainstream $fdwname compiled and tested at ";
+date;

--- a/testing/mulver_test.sh
+++ b/testing/mulver_test.sh
@@ -17,11 +17,10 @@ cd "$pg_multver_src_dir";
 echo "$ver" | while read ver_curs; do
 	[ "$one_ver" != "" ] && [ "$one_ver" != "$ver_curs" ] && continue;
 	basedir="REL_$ver_curs/postgresql/contrib/$fdwname";
-	cd "$basedir";
-	pwd;
-	./test.sh;
-	cd ../../../..;
-	pwd;
+	(
+ 		cd "$basedir";
+		./test.sh;
+	)
 	# "Copy" diff files from regression tests from different PostgreSQL version source code trees.
 	rm "rel_$ver_curs regression.diff" 2> /dev/null;
 	ln -s -r "$basedir/regression.diffs" "$fdwname_${ver_curs}_regr.diff";

--- a/testing/mulver_test.sh
+++ b/testing/mulver_test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+[ "$1" == "" ] && exit;
+fdwname="$1";
+[ "$2" == "" ] && pg_multver_src_dir='PostgreSQL source' || pg_multver_src_dir="$2";
+baseadr=$(readlink -f "$0");
+baseadr=$(dirname "$baseadr");
+pg_multver_src_dir="$baseadr/$pg_multver_src_dir";
+[ ! -d "$pg_multver_src_dir" ] && (echo "No PostgreSQL source code directory
+Press any key"; read x; exit;);
+
+one_ver="$3";
+ver=$(ls -1 "$baseadr/$fdwname/expected/" | tr '.' '_');
+echo "$ver";
+
+cd "$pg_multver_src_dir";
+# Run $fdwname regression tests for tested version.
+echo "$ver" | while read ver_curs; do
+	[ "$one_ver" != "" ] && [ "$one_ver" != "$ver_curs" ] && continue;
+	basedir="REL_$ver_curs/postgresql/contrib/$fdwname";
+	cd "$basedir";
+	pwd;
+	./test.sh;
+	cd ../../../..;
+	pwd;
+	# "Copy" diff files from regression tests from different PostgreSQL version source code trees.
+	rm "rel_$ver_curs regression.diff" 2> /dev/null;
+	ln -s -r "$basedir/regression.diffs" "$fdwname_${ver_curs}_regr.diff";
+	ver0=$(echo "$ver_curs" | tr '_' '.');
+	ln -s -r "$basedir/results/$ver0" "$fdwname_${ver_curs}_results";
+done;
+
+cd ..;

--- a/testing/new_mulver_cycle.sh
+++ b/testing/new_mulver_cycle.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+[ "$1" == "" ] && exit;
+fdwname="$1";
+[ "$2" == "" ] && pg_multver_src_dir='PostgreSQL source' || pg_multver_src_dir="$2";
+baseadr=$(readlink -f "$0");
+baseadr=$(dirname "$baseadr");
+pg_multver_src_dir0="$pg_multver_src_dir"
+pg_multver_src_dir="$baseadr/$pg_multver_src_dir";
+[ ! -d "$pg_multver_src_dir" ] && (echo "No PostgreSQL source code directory
+Press any key"; read x; exit;);
+
+one_ver="$3";
+ver=$(ls -1 "$baseadr/$fdwname/expected/" | tr '.' '_');
+
+echo "$ver" | while read ver_curs; do
+	[ "$one_ver" != "" ] && [ "$one_ver" != "$ver_curs" ] && continue;
+	rm -v "$pg_multver_src_dir/$fdwname_${ver_curs}_regr.diff";
+	rm -v "$pg_multver_src_dir/$fdwname_${ver_curs}_results";
+done;
+
+# Run $fdwname regression tests for tested version.
+echo "$ver" | while read ver_curs; do
+	rm -r -f "$pg_multver_src_dir/REL_$ver_curs/postgresql/contrib/$fdwname";
+	cp -r "$baseadr/$fdwname" "$pg_multver_src_dir/REL_$ver_curs/postgresql/contrib";
+done;
+
+dir=$(readlink -f "$0");
+dir=$(dirname "$dir");
+"$dir/mulver_test.sh" "$fdwname" "$pg_multver_src_dir0" "$3" "$4";
+echo "TESTING CYCLE IS ENDED, PLEASE READ THE RESULTS!";


### PR DESCRIPTION
This scripts allows automatically get multiversional PostgreSQL source codes from official PGDG repository. With some untested limitations this is applicable also to other `pgspider` FDWs with `./test.sh` script in root source code directory.

No C-language review, please let review by compilation environment infrastructure engineers.