### PR TITLE
Add mixed affinity `UPDATE`, unify UUID behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OBJS = connection.o option.o deparse.o sqlite_query.o sqlite_fdw.o sqlite_data_n
 EXTENSION = sqlite_fdw
 DATA = sqlite_fdw--1.0.sql sqlite_fdw--1.0--1.1.sql
 
-REGRESS = extra/sqlite_fdw_post extra/float4 extra/float8 extra/int4 extra/int8 extra/numeric extra/bitstring extra/bool extra/timestamp extra/uuid extra/join extra/limit extra/aggregates extra/prepare extra/select_having extra/select extra/insert extra/update extra/encodings sqlite_fdw type aggregate selectfunc 
+REGRESS = extra/sqlite_fdw_post extra/bitstring extra/bool extra/float4 extra/float8 extra/int4 extra/int8 extra/numeric extra/out_of_range extra/timestamp extra/uuid extra/join extra/limit extra/aggregates extra/prepare extra/select_having extra/select extra/insert extra/update extra/encodings sqlite_fdw type aggregate selectfunc 
 REGRESS_OPTS = --encoding=utf8
 
 SQLITE_LIB = sqlite3

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OBJS = connection.o option.o deparse.o sqlite_query.o sqlite_fdw.o sqlite_data_n
 EXTENSION = sqlite_fdw
 DATA = sqlite_fdw--1.0.sql sqlite_fdw--1.0--1.1.sql
 
-REGRESS = extra/sqlite_fdw_post extra/float4 extra/float8 extra/int4 extra/int8 extra/numeric extra/join extra/limit extra/aggregates extra/prepare extra/select_having extra/select extra/insert extra/update extra/timestamp extra/encodings extra/bool extra/uuid sqlite_fdw type aggregate selectfunc 
+REGRESS = extra/sqlite_fdw_post extra/float4 extra/float8 extra/int4 extra/int8 extra/numeric extra/bitstring extra/bool extra/timestamp extra/uuid extra/join extra/limit extra/aggregates extra/prepare extra/select_having extra/select extra/insert extra/update extra/encodings sqlite_fdw type aggregate selectfunc 
 REGRESS_OPTS = --encoding=utf8
 
 SQLITE_LIB = sqlite3

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Features
 - Support Bulk `INSERT` by using `batch_size` option
 - Support `INSERT`/`UPDATE` with generated column
 - Support `ON CONFLICT DO NOTHING`
-- Support mixed SQLite [data affinity](https://www.sqlite.org/datatype3.html) input and filtering (`SELECT`/`WHERE` usage) for such dataypes as
+- Support mixed SQLite [data affinity](https://www.sqlite.org/datatype3.html) input and filtering (`SELECT`/`WHERE` usage) for such data types as
 	- `timestamp`: `text` and `int`,
 	- `uuid`: `text`(32..39) and `blob`(16),
  	- `bool`: `text`(1..5) and `int`.
-- Support mixed SQLite [data affinity](https://www.sqlite.org/datatype3.html) output (`INSERT`/`UPDATE`) for such dataypes as
+- Support mixed SQLite [data affinity](https://www.sqlite.org/datatype3.html) output (`INSERT`/`UPDATE`) for such data types as
 	- `timestamp`: `text`(default) or `int`,
  	- `uuid`: `text`(36) or `blob`(16)(default).
 
@@ -55,7 +55,7 @@ Features
 - `mod()` is pushdowned. In PostgreSQL gives [argument-dependend data type](https://www.postgresql.org/docs/current/functions-math.html), but result from SQLite always [have `real` affinity](https://www.sqlite.org/lang_mathfunc.html#mod).
 - `upper`, `lower` and other character case functions are **not** pushed down because they does not work with UNICODE character in SQLite.
 - `WITH TIES` option is **not** pushed down.
-- Bit string `#` (XOR) operator is **not** pushed down becasuse there is no equal SQLite operator.
+- Bit string `#` (XOR) operator is **not** pushed down because there is no equal SQLite operator.
 
 ### Notes about pushdowning
 
@@ -69,7 +69,7 @@ Features
 - For `numeric` data type, `sqlite_fdw` use `sqlite3_column_double` to get value, while SQLite shell uses `sqlite3_column_text` to get value. Those 2 APIs may return different numeric value. Therefore, for `numeric` data type, the value returned from `sqlite_fdw` may different from the value returned from SQLite shell.
 - `sqlite_fdw` can return implementation-dependent order for column if the column is not specified in `ORDER BY` clause.
 - When the column type is `varchar array`, if the string is shorter than the declared length, values of type character will be space-padded; values of type `character varying` will simply store the shorter string.
-- [String literals for `boolean`](https://www.postgresql.org/docs/current/datatype-boolean.html) (`t`, `f`, `y`, `n`, `yes`, `no`, `on`, `off` etc. case insensetive) can be readed and filtred but cannot writed, because SQLite documentation recommends only `int` affinity values (`0` or `1`)  for boolean data and usually text boolean data belongs to legacy datasets.
+- [String literals for `boolean`](https://www.postgresql.org/docs/current/datatype-boolean.html) (`t`, `f`, `y`, `n`, `yes`, `no`, `on`, `off` etc. case insensitive) can be readed and filtred but cannot writed, because SQLite documentation recommends only `int` affinity values (`0` or `1`)  for boolean data and usually text boolean data belongs to legacy datasets.
 
 Also see [Limitations](#limitations)
 
@@ -300,7 +300,7 @@ sqlite_fdw_version
 Identifier case handling
 ------------------------
 
-PostgreSQL folds identifiers to lower case by default, SQLite is case insensetive by default
+PostgreSQL folds identifiers to lower case by default, SQLite is case insensitive by default
 and doesn't differ uppercase and lowercase ASCII base latin letters. It's important
 to be aware of potential issues with table and column names.
 
@@ -533,7 +533,7 @@ Limitations
 - For `sum` function of SQLite, output of `sum(bigint)` is `integer` value. If input values are big, the overflow error may occurs on SQLite because it overflow within the range of signed 64bit. For PostgreSQL, it can calculate as over the precision of `bigint`, so overflow does not occur.
 - SQLite promises to preserve the 15 most significant digits of a floating point value. The big value which exceed 15 most significant digits may become different value after inserted.
 - SQLite does not support `numeric` type as PostgreSQL. Therefore, it does not allow to store numbers with too high precision and scale. Error out of range occurs.
-- SQLite does not support special values for IEEE 754-2008 numbers such as `NaN`, `+Infinity` and `-Infinity` in SQL expressions with numeric context. Also SQLite can not store this values with `real` [affinity](https://www.sqlite.org/datatype3.html). In opposite to SQLite, PostgreSQL can store special values in columns belongs to `real` datatype family such as `float` or `double precision` and use arithmetic comparation for this values. In oppose to PostgreSQL, SQLite stores `NaN`, `+Infinity` and `-Infinity` as a text values. Also conditions with special literals (such as ` n < '+Infinity'` or ` m > '-Infinity'` ) isn't numeric conditions in SQLite and gives unexpected result after pushdowning in oppose to internal PostgreSQL calculations. During `INSERT INTO ... SELECT` or in `WHERE` conditions `sqlite_fdw` uses given by PostgreSQL standard case sensetive literals **only** in follow forms: `NaN`, `-Infinity`, `Infinity`, not original strings from `WHERE` condition. *This can caused selecting issues*.
+- SQLite does not support special values for IEEE 754-2008 numbers such as `NaN`, `+Infinity` and `-Infinity` in SQL expressions with numeric context. Also SQLite can not store this values with `real` [affinity](https://www.sqlite.org/datatype3.html). In opposite to SQLite, PostgreSQL can store special values in columns belongs to `real` datatype family such as `float` or `double precision` and use arithmetic comparation for this values. In oppose to PostgreSQL, SQLite stores `NaN`, `+Infinity` and `-Infinity` as a text values. Also conditions with special literals (such as ` n < '+Infinity'` or ` m > '-Infinity'` ) isn't numeric conditions in SQLite and gives unexpected result after pushdowning in oppose to internal PostgreSQL calculations. During `INSERT INTO ... SELECT` or in `WHERE` conditions `sqlite_fdw` uses given by PostgreSQL standard case sensitive literals **only** in follow forms: `NaN`, `-Infinity`, `Infinity`, not original strings from `WHERE` condition. *This can caused selecting issues*.
 
 ### Boolean values
 - `sqlite_fdw` boolean values support exists only for `bool` columns in foreign table. SQLite documentation recommends to store boolean as value with `integer` [affinity](https://www.sqlite.org/datatype3.html). `NULL` isn't converted, 1 converted to `true`, all other `NOT NULL` values converted to `false`. During `SELECT ... WHERE condition_column` condition converted only to `condition_column`.
@@ -546,7 +546,7 @@ for `INSERT` and `UPDATE` commands. PostgreSQL supports both `blob` and `text` [
 
 ### bit and varbit support
 - `sqlite_fdw` PostgreSQL `bit`/`varbit` values support based on `int` SQLite data affinity, because there is no per bit operations for SQLite `blob` affinity data. Maximum SQLite `int` affinity value is 8 bytes length, hence maximum `bit`/`varbit` values length is 64 bits.
-- `sqlite_fdw` doesn't pushdown `#` (XOR) operator becasuse there is no equal SQLite operator.
+- `sqlite_fdw` doesn't pushdown `#` (XOR) operator because there is no equal SQLite operator.
 
 Tests
 -----

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ In OS `sqlite_fdw` works as executed code with permissions of user of PostgreSQL
 in SQLite (mixed affinity case). Updated and inserted values will have this affinity. Default preferred SQLite affinity for `timestamp` and `uuid` PostgreSQL data types is `text`.
 
   - Use `INT` value for SQLite column (epoch Unix Time) to be treated/visualized as `timestamp` in PostgreSQL.
-  - Use `BLOB` value for SQLite column to be treated/visualized as `uuid` in PostgreSQL 14+.
+  - Use `BLOB` value for SQLite column to be treated/visualized as `uuid`.
 
 - **key** as *boolean*, optional, default *false*
 
@@ -542,7 +542,7 @@ Limitations
 ### UUID values
 - `sqlite_fdw` UUID values support exists only for `uuid` columns in foreign table. SQLite documentation recommends to store UUID as value with both `blob` and `text` [affinity](https://www.sqlite.org/datatype3.html). `sqlite_fdw` can pushdown both reading and filtering both `text` and `blob` values.
 - Expected affinity of UUID value in SQLite table determined by `column_type` option of the column
-for `INSERT` and `UPDATE` commands. In PostgreSQL 14- only `text` data affinity is availlable, PostgreSQL 14+ supports also `blob` data affinity.
+for `INSERT` and `UPDATE` commands. PostgreSQL supports both `blob` and `text` [affinity](https://www.sqlite.org/datatype3.html).
 
 ### bit and varbit support
 - `sqlite_fdw` PostgreSQL `bit`/`varbit` values support based on `int` SQLite data affinity, because there is no per bit operations for SQLite `blob` affinity data. Maximum SQLite `int` affinity value is 8 bytes length, hence maximum `bit`/`varbit` values length is 64 bits.
@@ -552,7 +552,7 @@ Tests
 -----
 Test directory have structure as following:
 
-```sql
+```
 +---sql
 |   +---12.16
 |   |       filename1.sql

--- a/deparse.c
+++ b/deparse.c
@@ -164,6 +164,7 @@ static void sqlite_get_relation_column_alias_ids(Var *node, RelOptInfo *foreignr
 static char *sqlite_quote_identifier(const char *s, char q);
 static bool sqlite_contain_immutable_functions_walker(Node *node, void *context);
 static bool sqlite_is_valid_type(Oid type);
+int preferred_sqlite_affinity (Oid relid, int varattno);
 
 /*
  * Append remote name of specified foreign table to buf.
@@ -2107,6 +2108,9 @@ sqlite_deparse_column_ref(StringInfo buf, int varno, int varattno, PlannerInfo *
 	}
 }
 
+/*
+ * Get column option with optionname for a variable attribute in deparsing context
+ */
 static char *
 sqlite_deparse_column_option(int varno, int varattno, PlannerInfo *root, char *optionname)
 {
@@ -2296,6 +2300,35 @@ sqlite_deparse_update(StringInfo buf, PlannerInfo *root,
 	}
 }
 
+/* Preferred SQLite affinity from "column_type" foreign column option
+ * SQLITE_NULL if no value or no normal value
+ */
+int
+preferred_sqlite_affinity (Oid relid, int varattno)
+{
+	char	   *coltype = NULL;
+	List	   *options;
+	ListCell   *lc;
+
+	elog(DEBUG4, "sqlite_fdw : %s ", __func__);
+	if (varattno == 0)
+		return SQLITE_NULL;
+
+	options = GetForeignColumnOptions(relid, varattno);
+	foreach(lc, options)
+	{
+		DefElem	*def = (DefElem *) lfirst(lc);
+
+		if (strcmp(def->defname, "column_type") == 0)
+		{
+			coltype = defGetString(def);
+			break;
+		}
+		elog(DEBUG4, "column type = %s", coltype);
+	}
+	return sqlite_affinity_code(coltype);
+}
+
 /*
  * deparse remote UPDATE statement
  *
@@ -2346,7 +2379,11 @@ sqlite_deparse_direct_update_sql(StringInfo buf, PlannerInfo *root,
 	forboth(lc, targetlist, lc2, targetAttrs)
 	{
 		int			attnum = lfirst_int(lc2);
+		int			preferred_affinity = SQLITE_NULL;
 		TargetEntry *tle;
+		RangeTblEntry *rte;
+		bool		special_affinity = false;
+		Oid			pg_attyp;
 #if (PG_VERSION_NUM >= 140000)
 		tle = lfirst_node(TargetEntry, lc);
 
@@ -2366,8 +2403,27 @@ sqlite_deparse_direct_update_sql(StringInfo buf, PlannerInfo *root,
 		first = false;
 
 		sqlite_deparse_column_ref(buf, rtindex, attnum, root, false, true);
+
+		/* Get RangeTblEntry from array in PlannerInfo. */
+		rte = planner_rt_fetch(rtindex, root);
+		pg_attyp = get_atttype(rte->relid, attnum);
+		preferred_affinity = preferred_sqlite_affinity(rte->relid, attnum);
+
 		appendStringInfoString(buf, " = ");
+
+		special_affinity = (pg_attyp == UUIDOID && preferred_affinity == SQLITE3_TEXT) ||
+						   (pg_attyp == TIMESTAMPOID && preferred_affinity == SQLITE_INTEGER);
+		if (special_affinity)
+		{
+			elog(DEBUG3, "sqlite_fdw : aff %d\n", preferred_affinity);
+			if (pg_attyp == UUIDOID && preferred_affinity == SQLITE3_TEXT)
+				appendStringInfo(buf, "sqlite_fdw_uuid_str(");
+			if (pg_attyp == TIMESTAMPOID && preferred_affinity == SQLITE_INTEGER)
+				appendStringInfo(buf, "strftime(");
+		}
 		sqlite_deparse_expr((Expr *) tle->expr, &context);
+    	if (special_affinity)
+			appendStringInfoString(buf, ")");
 	}
 
 	sqlite_reset_transmission_modes(nestlevel);

--- a/deparse.c
+++ b/deparse.c
@@ -164,7 +164,7 @@ static void sqlite_get_relation_column_alias_ids(Var *node, RelOptInfo *foreignr
 static char *sqlite_quote_identifier(const char *s, char q);
 static bool sqlite_contain_immutable_functions_walker(Node *node, void *context);
 static bool sqlite_is_valid_type(Oid type);
-int preferred_sqlite_affinity (Oid relid, int varattno);
+static int preferred_sqlite_affinity (Oid relid, int varattno);
 
 /*
  * Append remote name of specified foreign table to buf.
@@ -2300,7 +2300,8 @@ sqlite_deparse_update(StringInfo buf, PlannerInfo *root,
 	}
 }
 
-/* Preferred SQLite affinity from "column_type" foreign column option
+/*
+ * Preferred SQLite affinity from "column_type" foreign column option
  * SQLITE_NULL if no value or no normal value
  */
 int
@@ -2322,9 +2323,9 @@ preferred_sqlite_affinity (Oid relid, int varattno)
 		if (strcmp(def->defname, "column_type") == 0)
 		{
 			coltype = defGetString(def);
+			elog(DEBUG4, "column type = %s", coltype);
 			break;
 		}
-		elog(DEBUG4, "column type = %s", coltype);
 	}
 	return sqlite_affinity_code(coltype);
 }
@@ -2422,7 +2423,7 @@ sqlite_deparse_direct_update_sql(StringInfo buf, PlannerInfo *root,
 				appendStringInfo(buf, "strftime(");
 		}
 		sqlite_deparse_expr((Expr *) tle->expr, &context);
-    	if (special_affinity)
+		if (special_affinity)
 			appendStringInfoString(buf, ")");
 	}
 

--- a/deparse.c
+++ b/deparse.c
@@ -2415,11 +2415,15 @@ sqlite_deparse_direct_update_sql(StringInfo buf, PlannerInfo *root,
 		{
 			appendStringInfo(buf, "sqlite_fdw_uuid_str(");
 			special_affinity = true;
-		} else if (pg_attyp == TIMESTAMPOID && preferred_affinity == SQLITE_INTEGER)
-		{
-			appendStringInfo(buf, "strftime(");
-			special_affinity = true;
 		}
+		/* TODO: add TCs in future PR about mixed affinity
+		 * timestamp about fixing the same error
+		 *  else if (pg_attyp == TIMESTAMPOID && preferred_affinity == SQLITE_INTEGER)
+		 * {
+		 *	appendStringInfo(buf, "strftime(");
+		 *	special_affinity = true;
+		 * }
+		 */
 		sqlite_deparse_expr((Expr *) tle->expr, &context);
 
 		if (special_affinity)

--- a/deparse.c
+++ b/deparse.c
@@ -2416,14 +2416,6 @@ sqlite_deparse_direct_update_sql(StringInfo buf, PlannerInfo *root,
 			appendStringInfo(buf, "sqlite_fdw_uuid_str(");
 			special_affinity = true;
 		}
-		/* TODO: add TCs in future PR about mixed affinity
-		 * timestamp about fixing the same error
-		 *  else if (pg_attyp == TIMESTAMPOID && preferred_affinity == SQLITE_INTEGER)
-		 * {
-		 *	appendStringInfo(buf, "strftime(");
-		 *	special_affinity = true;
-		 * }
-		 */
 		sqlite_deparse_expr((Expr *) tle->expr, &context);
 
 		if (special_affinity)

--- a/expected/12.16/extra/uuid.out
+++ b/expected/12.16/extra/uuid.out
@@ -1,125 +1,125 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=1 width=20)
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+ Insert on public."type_UUID"
+   ->  Result
          Output: 28, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (3 rows)
 
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=1 width=20)
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+ Insert on public."type_UUID"
+   ->  Result
          Output: 39, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (3 rows)
 
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -165,9 +165,9 @@ SELECT * FROM "type_UUID+";
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
 (40 rows)
 
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -193,19 +193,19 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
 (20 rows)
 
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -231,17 +231,17 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
 (20 rows)
 
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -267,9 +267,9 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
 (20 rows)
 
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -295,45 +295,45 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
 (20 rows)
 
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb9bd380a15') WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a12'))
 (3 rows)
 
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -360,153 +360,172 @@ SELECT * FROM "type_UUID+";
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
 (21 rows)
 
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | blob | 16
 (1 row)
 
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
  i | u | t | l 
 ---+---+---+---
 (0 rows)
 
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  41 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | text | 36
 (1 row)
 
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb900000a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb900000a15') WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb900000a15'))
 (3 rows)
 
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (17 bytes) in hex : a0eebc999c0b4ef8bb6d6bb9bd380a11f1
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (15 bytes) in hex : b0eebc999c0b4ef8bb6d6bb9bd380a
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..29.00 rows=29 width=4)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..29.00 rows=29 width=4)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE (`i` IN (42, 43))
 (3 rows)
 
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
  44 |                                      | null |   
 (2 rows)
 
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
  i  | u |  t   | l 
 ----+---+------+---
  44 |   | null |  
 (1 row)
 
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NULL))
 (3 rows)
 
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
                                                                QUERY PLAN                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..1045.00 rows=1045 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NOT NULL))
 (3 rows)
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
+   sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
+   sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to server sqlite_svr
 drop cascades to foreign table "type_UUID"
 drop cascades to foreign table "type_UUID+"
+drop cascades to foreign table "type_UUIDpk"
 drop cascades to server sqlite2

--- a/expected/12.16/extra/uuid.out
+++ b/expected/12.16/extra/uuid.out
@@ -151,18 +151,18 @@ SELECT * FROM "type_UUID+";
  26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (40 rows)
 
 --Testcase 058:
@@ -185,12 +185,12 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  20 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
 --Testcase 060:
@@ -223,12 +223,12 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  20 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
 --Testcase 063:
@@ -259,12 +259,12 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
 --Testcase 065:
@@ -287,12 +287,12 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
 --Testcase 067:
@@ -352,12 +352,12 @@ SELECT * FROM "type_UUID+";
  21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | blob | 16
- 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (21 rows)
 
 --Testcase 075:
@@ -506,20 +506,37 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
-ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
-   sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
 --Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(2 rows)
+
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
    sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(3 rows)
+
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 --Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/expected/12.16/type.out
+++ b/expected/12.16/type.out
@@ -295,7 +295,6 @@ SELECT * FROM type_JSON;
 
 --Testcase 57
 DELETE FROM type_JSON;
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -510,6 +509,44 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;
 NOTICE:  drop cascades to 48 other objects

--- a/expected/13.12/extra/uuid.out
+++ b/expected/13.12/extra/uuid.out
@@ -1,125 +1,125 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=1 width=20)
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+ Insert on public."type_UUID"
+   ->  Result
          Output: 28, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (3 rows)
 
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=1 width=20)
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+ Insert on public."type_UUID"
+   ->  Result
          Output: 39, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (3 rows)
 
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -165,9 +165,9 @@ SELECT * FROM "type_UUID+";
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
 (40 rows)
 
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -193,19 +193,19 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
 (20 rows)
 
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -231,17 +231,17 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
 (20 rows)
 
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -267,9 +267,9 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
 (20 rows)
 
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -295,45 +295,45 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
 (20 rows)
 
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb9bd380a15') WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a12'))
 (3 rows)
 
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -360,153 +360,172 @@ SELECT * FROM "type_UUID+";
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
 (21 rows)
 
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | blob | 16
 (1 row)
 
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
  i | u | t | l 
 ---+---+---+---
 (0 rows)
 
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  41 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | text | 36
 (1 row)
 
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb900000a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb900000a15') WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..15.00 rows=15 width=24)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb900000a15'))
 (3 rows)
 
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (17 bytes) in hex : a0eebc999c0b4ef8bb6d6bb9bd380a11f1
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (15 bytes) in hex : b0eebc999c0b4ef8bb6d6bb9bd380a
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..29.00 rows=29 width=4)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..29.00 rows=29 width=4)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE (`i` IN (42, 43))
 (3 rows)
 
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
  44 |                                      | null |   
 (2 rows)
 
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
  i  | u |  t   | l 
 ----+---+------+---
  44 |   | null |  
 (1 row)
 
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NULL))
 (3 rows)
 
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
                                                                QUERY PLAN                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..1045.00 rows=1045 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NOT NULL))
 (3 rows)
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
+   sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
+   sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to server sqlite_svr
 drop cascades to foreign table "type_UUID"
 drop cascades to foreign table "type_UUID+"
+drop cascades to foreign table "type_UUIDpk"
 drop cascades to server sqlite2

--- a/expected/13.12/extra/uuid.out
+++ b/expected/13.12/extra/uuid.out
@@ -151,18 +151,18 @@ SELECT * FROM "type_UUID+";
  26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (40 rows)
 
 --Testcase 058:
@@ -185,12 +185,12 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  20 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
 --Testcase 060:
@@ -223,12 +223,12 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  20 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
 --Testcase 063:
@@ -259,12 +259,12 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
 --Testcase 065:
@@ -287,12 +287,12 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  26 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  27 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
  28 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
- 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | text | 36
+ 35 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 36 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 37 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 38 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 39 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
+ 40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
 --Testcase 067:
@@ -352,12 +352,12 @@ SELECT * FROM "type_UUID+";
  21 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  22 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
  25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | blob | 16
- 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
- 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | text | 36
+ 29 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 30 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 31 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 32 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 33 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
+ 34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (21 rows)
 
 --Testcase 075:
@@ -506,20 +506,37 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
-ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
-   sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
 --Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(2 rows)
+
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
    sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(3 rows)
+
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 --Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/expected/13.12/type.out
+++ b/expected/13.12/type.out
@@ -295,7 +295,6 @@ SELECT * FROM type_JSON;
 
 --Testcase 57
 DELETE FROM type_JSON;
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -510,6 +509,44 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;
 NOTICE:  drop cascades to 48 other objects

--- a/expected/14.9/extra/uuid.out
+++ b/expected/14.9/extra/uuid.out
@@ -508,18 +508,37 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
+--Testcase 104:
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(2 rows)
+
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
    sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
---Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(3 rows)
+
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 --Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/expected/14.9/extra/uuid.out
+++ b/expected/14.9/extra/uuid.out
@@ -1,127 +1,127 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=0 width=0)
+ Insert on public."type_UUID"
    Batch Size: 1
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+   ->  Result
          Output: 28, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (4 rows)
 
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=0 width=0)
+ Insert on public."type_UUID"
    Batch Size: 1
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+   ->  Result
          Output: 39, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (4 rows)
 
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -167,9 +167,9 @@ SELECT * FROM "type_UUID+";
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (40 rows)
 
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -195,19 +195,19 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -233,17 +233,17 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -269,9 +269,9 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -297,45 +297,45 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb9bd380a15') WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=0 width=0)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a12'))
 (3 rows)
 
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -362,153 +362,170 @@ SELECT * FROM "type_UUID+";
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (21 rows)
 
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | blob | 16
 (1 row)
 
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=0 width=0)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
  i | u | t | l 
 ---+---+---+---
 (0 rows)
 
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  41 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | text | 36
 (1 row)
 
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb900000a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb900000a15') WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb900000a15'))
 (3 rows)
 
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (17 bytes) in hex : a0eebc999c0b4ef8bb6d6bb9bd380a11f1
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (15 bytes) in hex : b0eebc999c0b4ef8bb6d6bb9bd380a
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..29.00 rows=0 width=0)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..29.00 rows=29 width=4)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE (`i` IN (42, 43))
 (3 rows)
 
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
  44 |                                      | null |   
 (2 rows)
 
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
  i  | u |  t   | l 
 ----+---+------+---
  44 |   | null |  
 (1 row)
 
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NULL))
 (3 rows)
 
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
                                                                QUERY PLAN                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..1045.00 rows=1045 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NOT NULL))
 (3 rows)
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
+   sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to server sqlite_svr
 drop cascades to foreign table "type_UUID"
 drop cascades to foreign table "type_UUID+"
+drop cascades to foreign table "type_UUIDpk"
 drop cascades to server sqlite2

--- a/expected/14.9/type.out
+++ b/expected/14.9/type.out
@@ -295,7 +295,6 @@ SELECT * FROM type_JSON;
 
 --Testcase 57
 DELETE FROM type_JSON;
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -510,6 +509,44 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;
 NOTICE:  drop cascades to 48 other objects

--- a/expected/15.4/extra/uuid.out
+++ b/expected/15.4/extra/uuid.out
@@ -508,18 +508,37 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
+--Testcase 104:
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(2 rows)
+
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
    sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
---Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(3 rows)
+
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 --Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/expected/15.4/extra/uuid.out
+++ b/expected/15.4/extra/uuid.out
@@ -1,127 +1,127 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=0 width=0)
+ Insert on public."type_UUID"
    Batch Size: 1
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+   ->  Result
          Output: 28, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (4 rows)
 
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=0 width=0)
+ Insert on public."type_UUID"
    Batch Size: 1
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+   ->  Result
          Output: 39, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (4 rows)
 
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -167,9 +167,9 @@ SELECT * FROM "type_UUID+";
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (40 rows)
 
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -195,19 +195,19 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -233,17 +233,17 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -269,9 +269,9 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -297,45 +297,45 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb9bd380a15') WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=0 width=0)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a12'))
 (3 rows)
 
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -362,153 +362,170 @@ SELECT * FROM "type_UUID+";
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (21 rows)
 
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | blob | 16
 (1 row)
 
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=0 width=0)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
  i | u | t | l 
 ---+---+---+---
 (0 rows)
 
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  41 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | text | 36
 (1 row)
 
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb900000a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb900000a15') WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb900000a15'))
 (3 rows)
 
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (17 bytes) in hex : a0eebc999c0b4ef8bb6d6bb9bd380a11f1
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (15 bytes) in hex : b0eebc999c0b4ef8bb6d6bb9bd380a
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..29.00 rows=0 width=0)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..29.00 rows=29 width=4)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE (`i` IN (42, 43))
 (3 rows)
 
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
  44 |                                      | null |   
 (2 rows)
 
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
  i  | u |  t   | l 
 ----+---+------+---
  44 |   | null |  
 (1 row)
 
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NULL))
 (3 rows)
 
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
                                                                QUERY PLAN                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..1045.00 rows=1045 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NOT NULL))
 (3 rows)
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
+   sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to server sqlite_svr
 drop cascades to foreign table "type_UUID"
 drop cascades to foreign table "type_UUID+"
+drop cascades to foreign table "type_UUIDpk"
 drop cascades to server sqlite2

--- a/expected/15.4/type.out
+++ b/expected/15.4/type.out
@@ -295,7 +295,6 @@ SELECT * FROM type_JSON;
 
 --Testcase 57
 DELETE FROM type_JSON;
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -510,6 +509,44 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;
 NOTICE:  drop cascades to 48 other objects

--- a/expected/16.0/extra/uuid.out
+++ b/expected/16.0/extra/uuid.out
@@ -508,18 +508,37 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
+--Testcase 104:
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(2 rows)
+
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
    sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
---Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+                 col                  
+--------------------------------------
+ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+ b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+(3 rows)
+
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 --Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/expected/16.0/extra/uuid.out
+++ b/expected/16.0/extra/uuid.out
@@ -1,127 +1,127 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=0 width=0)
+ Insert on public."type_UUID"
    Batch Size: 1
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+   ->  Result
          Output: 28, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (4 rows)
 
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
                             QUERY PLAN                            
 ------------------------------------------------------------------
- Insert on public."type_UUID"  (cost=0.00..0.01 rows=0 width=0)
+ Insert on public."type_UUID"
    Batch Size: 1
-   ->  Result  (cost=0.00..0.01 rows=1 width=20)
+   ->  Result
          Output: 39, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12'::uuid
 (4 rows)
 
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -167,9 +167,9 @@ SELECT * FROM "type_UUID+";
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (40 rows)
 
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -195,19 +195,19 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -233,17 +233,17 @@ SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (20 rows)
 
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
                                                                             QUERY PLAN                                                                            
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'a0eebc999c0b4ef8bb6d6bb9bd380a11'))
 (3 rows)
 
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -269,9 +269,9 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -297,45 +297,45 @@ SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
  40 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12 | blob | 16
 (20 rows)
 
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
                                                    QUERY PLAN                                                   
 ----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
-                                                   QUERY PLAN                                                   
-----------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((`i` = 25))
+                                                             QUERY PLAN                                                              
+-------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb9bd380a15') WHERE ((`i` = 25))
 (3 rows)
 
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=0 width=0)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a12'))
 (3 rows)
 
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
@@ -362,153 +362,170 @@ SELECT * FROM "type_UUID+";
  34 | a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 | blob | 16
 (21 rows)
 
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  25 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | blob | 16
 (1 row)
 
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
                                                           QUERY PLAN                                                          
 ------------------------------------------------------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..15.00 rows=0 width=0)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..15.00 rows=15 width=4)
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
  i | u | t | l 
 ---+---+---+---
 (0 rows)
 
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
  41 | b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15 | text | 36
 (1 row)
 
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
-                                                                              QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
-         SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb900000a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
+         SQLite query: UPDATE main."type_UUID" SET `u` = sqlite_fdw_uuid_str(X'b0eebc999c0b4ef8bb6d6bb900000a15') WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb9bd380a15'))
 (3 rows)
 
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Update on public."type_UUID"  (cost=10.00..6.00 rows=0 width=0)
-   ->  Foreign Update on public."type_UUID"  (cost=10.00..6.00 rows=6 width=64)
+ Update on public."type_UUID"
+   ->  Foreign Update on public."type_UUID"
          SQLite query: UPDATE main."type_UUID" SET `u` = X'b0eebc999c0b4ef8bb6d6bb9bd380a15' WHERE ((sqlite_fdw_uuid_blob(`u`) = X'b0eebc999c0b4ef8bb6d6bb900000a15'))
 (3 rows)
 
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (17 bytes) in hex : a0eebc999c0b4ef8bb6d6bb9bd380a11f1
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
 ERROR:  PostgreSQL uuid data type allows only 16 bytes SQLite blob value
 HINT:  SQLite value with "blob" affinity (15 bytes) in hex : b0eebc999c0b4ef8bb6d6bb9bd380a
 CONTEXT:  foreign table "type_UUID+" foreign column "u" have data type "uuid" (usual affinity "blob"), in query there is reference to foreign column
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
-                                   QUERY PLAN                                    
----------------------------------------------------------------------------------
- Delete on public."type_UUID"  (cost=10.00..29.00 rows=0 width=0)
-   ->  Foreign Delete on public."type_UUID"  (cost=10.00..29.00 rows=29 width=4)
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Delete on public."type_UUID"
+   ->  Foreign Delete on public."type_UUID"
          SQLite query: DELETE FROM main."type_UUID" WHERE (`i` IN (42, 43))
 (3 rows)
 
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
  44 |                                      | null |   
 (2 rows)
 
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
  i  | u |  t   | l 
 ----+---+------+---
  44 |   | null |  
 (1 row)
 
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
  i  |                  u                   |  t   | l  
 ----+--------------------------------------+------+----
- 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | blob | 16
+ 41 | b0eebc99-9c0b-4ef8-bb6d-6bb900000a15 | text | 36
 (1 row)
 
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
                                                              QUERY PLAN                                                             
 ------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..5.00 rows=5 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NULL))
 (3 rows)
 
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
                                                                QUERY PLAN                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on public."type_UUID+"  (cost=10.00..1045.00 rows=1045 width=54)
+ Foreign Scan on public."type_UUID+"
    Output: i, u, t, l
    SQLite query: SELECT `i`, sqlite_fdw_uuid_blob(`u`), `t`, `l` FROM main."type_UUID+" WHERE ((sqlite_fdw_uuid_blob(`u`) IS NOT NULL))
 (3 rows)
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_UUIDpk.col 
+   sql=INSERT INTO main."type_UUIDpk"(`col`) VALUES (?)
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;
-NOTICE:  drop cascades to 4 other objects
+NOTICE:  drop cascades to 5 other objects
 DETAIL:  drop cascades to server sqlite_svr
 drop cascades to foreign table "type_UUID"
 drop cascades to foreign table "type_UUID+"
+drop cascades to foreign table "type_UUIDpk"
 drop cascades to server sqlite2

--- a/expected/16.0/type.out
+++ b/expected/16.0/type.out
@@ -295,7 +295,6 @@ SELECT * FROM type_JSON;
 
 --Testcase 57
 DELETE FROM type_JSON;
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -510,6 +509,44 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+ERROR:  failed to execute remote SQL: rc=19 UNIQUE constraint failed: type_DOUBLE.col 
+   sql=INSERT INTO main."type_DOUBLE"(`col`) VALUES (?)
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+        col        
+-------------------
+          1999.012
+ 3.141592653589793
+          Infinity
+         -Infinity
+(4 rows)
+
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;
 NOTICE:  drop cascades to 48 other objects

--- a/sql/12.16/extra/uuid.sql
+++ b/sql/12.16/extra/uuid.sql
@@ -212,16 +212,22 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
+SELECT * FROM "type_UUIDpk";
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 
 --Testcase 200:

--- a/sql/12.16/extra/uuid.sql
+++ b/sql/12.16/extra/uuid.sql
@@ -1,213 +1,228 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
 
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
 
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/12.16/type.sql
+++ b/sql/12.16/type.sql
@@ -138,7 +138,6 @@ SELECT * FROM type_JSON;
 --Testcase 57
 DELETE FROM type_JSON;
 
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -259,6 +258,23 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
 
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/13.12/extra/uuid.sql
+++ b/sql/13.12/extra/uuid.sql
@@ -212,16 +212,22 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
+SELECT * FROM "type_UUIDpk";
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 
 --Testcase 200:

--- a/sql/13.12/extra/uuid.sql
+++ b/sql/13.12/extra/uuid.sql
@@ -1,213 +1,228 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
 
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
 
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/13.12/type.sql
+++ b/sql/13.12/type.sql
@@ -138,7 +138,6 @@ SELECT * FROM type_JSON;
 --Testcase 57
 DELETE FROM type_JSON;
 
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -259,6 +258,23 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
 
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/14.9/extra/uuid.sql
+++ b/sql/14.9/extra/uuid.sql
@@ -212,16 +212,22 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
+SELECT * FROM "type_UUIDpk";
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 
 --Testcase 200:

--- a/sql/14.9/extra/uuid.sql
+++ b/sql/14.9/extra/uuid.sql
@@ -1,213 +1,228 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
 
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
 
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/14.9/type.sql
+++ b/sql/14.9/type.sql
@@ -138,7 +138,6 @@ SELECT * FROM type_JSON;
 --Testcase 57
 DELETE FROM type_JSON;
 
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -259,6 +258,23 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
 
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/15.4/extra/uuid.sql
+++ b/sql/15.4/extra/uuid.sql
@@ -212,16 +212,22 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
+SELECT * FROM "type_UUIDpk";
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 
 --Testcase 200:

--- a/sql/15.4/extra/uuid.sql
+++ b/sql/15.4/extra/uuid.sql
@@ -1,213 +1,228 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
 
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
 
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/15.4/type.sql
+++ b/sql/15.4/type.sql
@@ -138,7 +138,6 @@ SELECT * FROM type_JSON;
 --Testcase 57
 DELETE FROM type_JSON;
 
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -259,6 +258,23 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
 
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/16.0/extra/uuid.sql
+++ b/sql/16.0/extra/uuid.sql
@@ -212,16 +212,22 @@ SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 --Testcase 100:
 CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
 --Testcase 101:
-INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'TEXT');
 --Testcase 102:
-INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 103:
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 104:
-ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
---Testcase 105: NO ERR, but the same semantics!
+SELECT * FROM "type_UUIDpk";
+--Testcase 105: ERR - primary key
 INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
 --Testcase 106:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (SET column_type 'BLOB');
+--Testcase 107: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 108:
+SELECT * FROM "type_UUIDpk";
+--Testcase 109:
 DELETE FROM "type_UUIDpk";
 
 --Testcase 200:

--- a/sql/16.0/extra/uuid.sql
+++ b/sql/16.0/extra/uuid.sql
@@ -1,213 +1,228 @@
 --SET log_min_messages  TO DEBUG1;
 --SET client_min_messages  TO DEBUG1;
---Testcase 44:
+--Testcase 001:
 CREATE EXTENSION sqlite_fdw;
---Testcase 45:
+--Testcase 002:
 CREATE SERVER sqlite_svr FOREIGN DATA WRAPPER sqlite_fdw
 OPTIONS (database '/tmp/sqlite_fdw_test/common.db');
 
---Testcase 46:
+--Testcase 003:
 CREATE SERVER sqlite2 FOREIGN DATA WRAPPER sqlite_fdw;
 
---Testcase 109:
+--Testcase 009:
 CREATE FOREIGN TABLE "type_UUID"( "i" int OPTIONS (key 'true'), "u" uuid) SERVER sqlite_svr OPTIONS (table 'type_UUID');
---Testcase 110:
+--Testcase 010:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE text;
---Testcase 111:
+--Testcase 011:
 INSERT INTO "type_UUID" ("i", "u") VALUES (1, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 112:
+--Testcase 012:
 INSERT INTO "type_UUID" ("i", "u") VALUES (2, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 113:
+--Testcase 013:
 INSERT INTO "type_UUID" ("i", "u") VALUES (3, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 114:
+--Testcase 014:
 INSERT INTO "type_UUID" ("i", "u") VALUES (4, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 115:
+--Testcase 015:
 INSERT INTO "type_UUID" ("i", "u") VALUES (5, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 116:
+--Testcase 016:
 INSERT INTO "type_UUID" ("i", "u") VALUES (6, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 117:
+--Testcase 017:
 INSERT INTO "type_UUID" ("i", "u") VALUES (7, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 118:
+--Testcase 018:
 INSERT INTO "type_UUID" ("i", "u") VALUES (8, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 119:
+--Testcase 019:
 INSERT INTO "type_UUID" ("i", "u") VALUES (9, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 120:
+--Testcase 020:
 INSERT INTO "type_UUID" ("i", "u") VALUES (10, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 121:
+--Testcase 021:
 INSERT INTO "type_UUID" ("i", "u") VALUES (11, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 122:
+--Testcase 022:
 INSERT INTO "type_UUID" ("i", "u") VALUES (12, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 123:
+--Testcase 023:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 124:
+--Testcase 024:
 INSERT INTO "type_UUID" ("i", "u") VALUES (13, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 125:
+--Testcase 025:
 INSERT INTO "type_UUID" ("i", "u") VALUES (14, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 126:
+--Testcase 026:
 INSERT INTO "type_UUID" ("i", "u") VALUES (15, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11', 'hex'));
---Testcase 127:
+--Testcase 027:
 INSERT INTO "type_UUID" ("i", "u") VALUES (16, decode('b0eebc999c0b4ef8bb6d6bb9bd380a12', 'hex'));
---Testcase 128:
+--Testcase 028:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 129:
+--Testcase 029:
 INSERT INTO "type_UUID" ("i", "u") VALUES (17, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 130:
+--Testcase 030:
 INSERT INTO "type_UUID" ("i", "u") VALUES (18, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 131:
+--Testcase 031:
 INSERT INTO "type_UUID" ("i", "u") VALUES (19, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 132:
+--Testcase 032:
 INSERT INTO "type_UUID" ("i", "u") VALUES (20, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 133:
+--Testcase 033:
 INSERT INTO "type_UUID" ("i", "u") VALUES (21, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 134:
+--Testcase 034:
 INSERT INTO "type_UUID" ("i", "u") VALUES (22, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 135:
+--Testcase 035:
 INSERT INTO "type_UUID" ("i", "u") VALUES (23, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 136:
+--Testcase 036:
 INSERT INTO "type_UUID" ("i", "u") VALUES (24, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 137:
+--Testcase 037:
 INSERT INTO "type_UUID" ("i", "u") VALUES (25, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 138:
+--Testcase 038:
 INSERT INTO "type_UUID" ("i", "u") VALUES (26, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 139:
+--Testcase 039:
 INSERT INTO "type_UUID" ("i", "u") VALUES (27, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 140:
+--Testcase 040:
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 141:
-EXPLAIN VERBOSE
+--Testcase 041:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (28, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 142:
+--Testcase 042:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (ADD column_type 'BLOB');
---Testcase 143:
+--Testcase 043:
 INSERT INTO "type_UUID" ("i", "u") VALUES (29, 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
---Testcase 144:
+--Testcase 044:
 INSERT INTO "type_UUID" ("i", "u") VALUES (30, 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11');
---Testcase 145:
+--Testcase 045:
 INSERT INTO "type_UUID" ("i", "u") VALUES (31, '{a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}');
---Testcase 146:
+--Testcase 046:
 INSERT INTO "type_UUID" ("i", "u") VALUES (32, 'a0eebc999c0b4ef8bb6d6bb9bd380a11');
---Testcase 147:
+--Testcase 047:
 INSERT INTO "type_UUID" ("i", "u") VALUES (33, 'a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11');
---Testcase 148:
+--Testcase 048:
 INSERT INTO "type_UUID" ("i", "u") VALUES (34, '{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
---Testcase 149:
+--Testcase 049:
 INSERT INTO "type_UUID" ("i", "u") VALUES (35, 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12');
---Testcase 150:
+--Testcase 050:
 INSERT INTO "type_UUID" ("i", "u") VALUES (36, 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12');
---Testcase 151:
+--Testcase 051:
 INSERT INTO "type_UUID" ("i", "u") VALUES (37, '{b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12}');
---Testcase 152:
+--Testcase 052:
 INSERT INTO "type_UUID" ("i", "u") VALUES (38, 'b0eebc999c0b4ef8bb6d6bb9bd380a12');
---Testcase 153:
+--Testcase 053:
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 154:
+--Testcase 054:
 INSERT INTO "type_UUID" ("i", "u") VALUES (40, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
---Testcase 155:
-EXPLAIN VERBOSE
+--Testcase 055:
+EXPLAIN (VERBOSE, COSTS OFF)
 INSERT INTO "type_UUID" ("i", "u") VALUES (39, 'b0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a12');
---Testcase 156:
+--Testcase 056:
 CREATE FOREIGN TABLE "type_UUID+"( "i" int OPTIONS (key 'true'), "u" uuid, "t" text, "l" smallint) SERVER sqlite_svr OPTIONS (table 'type_UUID+');
---Testcase 157:
+--Testcase 057:
 SELECT * FROM "type_UUID+";
---Testcase 158:
+--Testcase 058:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 159:
+--Testcase 059:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 160:
-EXPLAIN VERBOSE
+--Testcase 060:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 161:
+--Testcase 061:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 162:
+--Testcase 062:
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 163:
-EXPLAIN VERBOSE
+--Testcase 063:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" where "u" = 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11';
---Testcase 164:
+--Testcase 064:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 165:
+--Testcase 065:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 166:
+--Testcase 066:
 SELECT * FROM "type_UUID+" where "u" = 'B0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A12';
---Testcase 167:
+--Testcase 067:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 168:
-EXPLAIN VERBOSE
+--Testcase 068:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 169:
+--Testcase 069:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 170:
-EXPLAIN VERBOSE
+--Testcase 070:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "i" = 25;
---Testcase 171:
+--Testcase 071:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 172:
+--Testcase 072:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 173:
-EXPLAIN VERBOSE
+--Testcase 073:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a12';
---Testcase 174:
+--Testcase 074:
 SELECT * FROM "type_UUID+";
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11';
---Testcase 176:
+--Testcase 076:
 SELECT * FROM "type_UUID+";
---Testcase 177:
+--Testcase 077:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'TEXT');
---Testcase 175:
+--Testcase 075:
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 176:
-EXPLAIN VERBOSE
+--Testcase 076:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "u" = 'b0eebc999c0b4ef8bb6d6bb9bd380a15';
---Testcase 177:
+--Testcase 077:
 SELECT * FROM "type_UUID+";
---Testcase 178:
+--Testcase 078:
 INSERT INTO "type_UUID" ("i", "u") VALUES (41, '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}');
---Testcase 179:
+--Testcase 079:
 SELECT * FROM "type_UUID+" WHERE "i" = 41;
---Testcase 180:
+--Testcase 080:
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 181:
-EXPLAIN VERBOSE
+--Testcase 081:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}';
---Testcase 182:
+--Testcase 082:
 SELECT * FROM "type_UUID+";
---Testcase 183:
+--Testcase 083:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" OPTIONS (SET column_type 'BLOB');
---Testcase 184:
-EXPLAIN VERBOSE
+--Testcase 084:
+EXPLAIN (VERBOSE, COSTS OFF)
 UPDATE "type_UUID" SET "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a15}' WHERE "u" = '{b0eebc99-9c0b4ef8-bb6d6bb9-00000a15}';
---Testcase 185:
+--Testcase 085:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE bytea;
---Testcase 186:
+--Testcase 086:
 INSERT INTO "type_UUID" ("i", "u") VALUES (42, decode('a0eebc999c0b4ef8bb6d6bb9bd380a11f1', 'hex'));
---Testcase 187:
+--Testcase 087:
 INSERT INTO "type_UUID" ("i", "u") VALUES (43, decode('b0eebc999c0b4ef8bb6d6bb9bd380a', 'hex'));
---Testcase 188:
+--Testcase 088:
 ALTER FOREIGN TABLE "type_UUID" ALTER COLUMN "u" TYPE uuid;
---Testcase 189:
+--Testcase 089:
 SELECT * FROM "type_UUID+" WHERE "i" = 42;
---Testcase 190:
+--Testcase 090:
 SELECT * FROM "type_UUID+" WHERE "i" = 43;
---Testcase 191:
-EXPLAIN VERBOSE
+--Testcase 091:
+EXPLAIN (VERBOSE, COSTS OFF)
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 192:
+--Testcase 092:
 DELETE FROM "type_UUID" WHERE "i" IN (42, 43);
---Testcase 193:
+--Testcase 093:
 INSERT INTO "type_UUID" ("i", "u") VALUES (44, NULL);
---Testcase 194:
+--Testcase 094:
 SELECT * FROM "type_UUID+";
---Testcase 195:
+--Testcase 095:
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 196:
+--Testcase 096:
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
---Testcase 197:
-EXPLAIN VERBOSE
+--Testcase 097:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NULL;
---Testcase 198:
-EXPLAIN VERBOSE
+--Testcase 098:
+EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_UUID+" WHERE "u" IS NOT NULL;
 
---Testcase 47:
+--Testcase 100:
+CREATE FOREIGN TABLE "type_UUIDpk" (col uuid OPTIONS (key 'true')) SERVER sqlite_svr;
+--Testcase 101:
+INSERT INTO "type_UUIDpk" VALUES ('{a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}');
+--Testcase 102:
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 103: ERR - primary key
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 104:
+ALTER FOREIGN TABLE "type_UUIDpk" ALTER COLUMN col OPTIONS (ADD column_type 'BLOB');
+--Testcase 105: NO ERR, but the same semantics!
+INSERT INTO "type_UUIDpk" VALUES ('{b0eebc99-9c0b4ef8-bb6d6bb9-bd380a12}');
+--Testcase 106:
+DELETE FROM "type_UUIDpk";
+
+--Testcase 200:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sql/16.0/type.sql
+++ b/sql/16.0/type.sql
@@ -138,7 +138,6 @@ SELECT * FROM type_JSON;
 --Testcase 57
 DELETE FROM type_JSON;
 
--- drop column
 --Testcase 62:
 DROP FOREIGN TABLE IF EXISTS "type_BOOLEAN";
 --Testcase 63:
@@ -259,6 +258,23 @@ SELECT * FROM "type_DOUBLE"; -- OK
 
 --Testcase 107:
 ALTER FOREIGN TABLE "type_DOUBLE" ALTER COLUMN col TYPE float8;
+
+--Testcase 108:
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 109: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES (PI());
+--Testcase 110:
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 111:
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 113:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
+--Testcase 114: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('Infinity');
+--Testcase 115: ERR primary key
+INSERT INTO "type_DOUBLE" VALUES ('-Infinity');
+--Testcase 116:
+SELECT * FROM "type_DOUBLE"; -- OK, +- Inf
 
 --Testcase 47:
 DROP EXTENSION sqlite_fdw CASCADE;

--- a/sqlite_data_norm.c
+++ b/sqlite_data_norm.c
@@ -150,9 +150,8 @@ static void
 sqlite3UuidBlobToStr( const unsigned char *aBlob, unsigned char *zs)
 {
 	static const char hex_dig[] = "0123456789abcdef";
-	int i = 0, k;
 	unsigned char x;
-	k = 0x550;
+	int i = 0, k=0x550;
 	for(; i < UUID_LEN; i++, k = k >> 1)
 	{
 		if( k&1 )

--- a/sqlite_data_norm.c
+++ b/sqlite_data_norm.c
@@ -3,9 +3,10 @@
  * SQLite Foreign Data Wrapper for PostgreSQL
  *
  * SQLite functions for data normalization
- * This function is useful for mixed affinity inputs for PostgreSQL
- * data column. Also some UUID functions are implemented here according
- * the uuid SQLite exension, Public Domain
+ * This functions are used for mixed affinity inputs for PostgreSQL data column.
+ *
+ * Most of UUID functions are implemented here according
+ * the uuid SQLite extension, Public Domain
  * https://www.sqlite.org/src/file/ext/misc/uuid.c
  *
  * IDENTIFICATION
@@ -18,11 +19,10 @@
  * This SQLite extension implements functions that handling RFC-4122 UUIDs
  * Three SQL functions are implemented:
  *
- *	 gen_random_uuid() - generate a version 4 UUID as a string
- *	 uuid_str(X)	   - convert a UUID X into a well-formed UUID string
- *	 uuid_blob(X)	  - convert a UUID X into a 16-byte blob
+ *	 sqlite_fdw_uuid_str(X)   - convert a UUID X into a well-formed UUID string
+ *	 sqlite_fdw_uuid_blob(X)  - convert a UUID X into a 16-byte blob
  *
- * The output from gen_random_uuid() and uuid_str(X) are always well-formed
+ * The output from sqlite_fdw_uuid_str(X) are always well-formed
  * RFC-4122 UUID strings in this format:
  *
  *		xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
@@ -34,13 +34,13 @@
  * by values of N between '8' and 'b') as those are overwhelming the most
  * common.  Other variants are for legacy compatibility only.
  *
- * The output of uuid_blob(X) is always a 16-byte blob. The UUID input
+ * The output of sqlite_fdw_uuid_blob(X) is always a 16-byte blob. The UUID input
  * string is converted in network byte order (big-endian) in accordance
  * with RFC-4122 specifications for variant-1 UUIDs.  Note that network
  * byte order is *always* used, even if the input self-identifies as a
  * variant-2 UUID.
  *
- * The input X to the uuid_str() and uuid_blob() functions can be either
+ * The input X to the sqlite_fdw_uuid_blob() function can be either
  * a string or a BLOB. If it is a BLOB it must be exactly 16 bytes in
  * length or else a NULL is returned.  If the input is a string it must
  * consist of 32 hexadecimal digits, upper or lower case, optionally
@@ -55,8 +55,8 @@
  *	 a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11
  *	 {a0eebc99-9c0b4ef8-bb6d6bb9-bd380a11}
  *
- * If any of the above inputs are passed into uuid_str(), the output will
- * always be in the canonical RFC-4122 format:
+ * Output of sqlite_fdw_uuid_str() always will be
+ * in the canonical RFC-4122 format:
  *
  *	 a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
  *
@@ -150,10 +150,10 @@ static void
 sqlite3UuidBlobToStr( const unsigned char *aBlob, unsigned char *zs)
 {
 	static const char hex_dig[] = "0123456789abcdef";
-	int i, k;
+	int i = 0, k;
 	unsigned char x;
-	k = 0;
-	for(i=0, k=0x550; i<UUID_LEN; i++, k=k>>1)
+	k = 0x550;
+	for(; i < UUID_LEN; i++, k = k >> 1)
 	{
 		if( k&1 )
 		{
@@ -185,7 +185,7 @@ sqlite_fdw_uuid_str(sqlite3_context* context, int argc, sqlite3_value** argv)
 	{
 		pBlob = sqlite3_value_blob(arg);
 	}
-	if (t == SQLITE3_TEXT)
+	else if (t == SQLITE3_TEXT)
 	{
 		const unsigned char* txt = sqlite3_value_text(arg);
 		if (sqlite_fdw_uuid_blob(txt, aBlob))
@@ -196,7 +196,7 @@ sqlite_fdw_uuid_str(sqlite3_context* context, int argc, sqlite3_value** argv)
 			return;
 		}
 	}
-	if (t != SQLITE_BLOB)
+	else
 	{
 		sqlite3_result_null(context);
 		return;
@@ -348,6 +348,11 @@ error_helper(sqlite3* db, int rc)
 			 errhint("%s \n SQLite code %d", err, rc)));
 }
 
+/*
+ * Add data normalization fuctions to SQLite internal namespace for calling
+ * in deparse context.
+ * This is main function of internal SQLite extension presented in this file.
+ */
 void
 sqlite_fdw_data_norm_functs_init(sqlite3* db)
 {

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -5738,6 +5738,8 @@ sqlite_affinity_eqv_to_pgtype(Oid type)
 	}
 }
 
+static const char *azType[] = { "?", "integer", "real", "text", "blob", "null" };
+
 /*
  * sqlite_datatype
  * Give equivalent string for SQLite data affinity by int from enum
@@ -5746,7 +5748,6 @@ sqlite_affinity_eqv_to_pgtype(Oid type)
 const char*
 sqlite_datatype(int t)
 {
-	static const char *azType[] = { "?", "integer", "real", "text", "blob", "null" };
 	switch (t)
 	{
 		case SQLITE_INTEGER:
@@ -5762,6 +5763,28 @@ sqlite_datatype(int t)
 		default:
 			return azType[0];
 	}
+}
+
+/*
+ * Give SQLite affinity enum int for SQLite data affinity string
+ */
+const int
+sqlite_affinity_code(char* t)
+{
+	if ( t == NULL )
+	    return SQLITE_NULL;
+    if (strcasecmp(t, azType[1]) == 0 || strcasecmp(t, "int") == 0)
+        return SQLITE_INTEGER;
+    if (strcasecmp(t, azType[2]) == 0)
+        return SQLITE_FLOAT;
+    if (strcasecmp(t, azType[3]) == 0)
+        return SQLITE_TEXT;
+    if (strcasecmp(t, azType[4]) == 0)
+        return SQLITE_BLOB;
+    /* if (strcasecmp(t, azType[5]) == 0)
+     * error value
+     */
+    return SQLITE_NULL;
 }
 
 /*

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -5140,6 +5140,7 @@ sqlite_to_pg_type(StringInfo str, char *type)
 		{"boolean"},
 		{"varchar"},
 		{"char"},
+		{"uuid"},
 		{NULL}
 	};
 

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -390,6 +390,8 @@ static void conversion_error_callback(void *arg);
 static int32 sqlite_affinity_eqv_to_pgtype(Oid type);
 const char* sqlite_datatype(int t);
 
+static const char *azType[] = { "?", "integer", "real", "text", "blob", "null" };
+
 /* Callback argument for sqlite_ec_member_matches_foreign */
 typedef struct
 {
@@ -5739,8 +5741,6 @@ sqlite_affinity_eqv_to_pgtype(Oid type)
 	}
 }
 
-static const char *azType[] = { "?", "integer", "real", "text", "blob", "null" };
-
 /*
  * sqlite_datatype
  * Give equivalent string for SQLite data affinity by int from enum
@@ -5773,19 +5773,16 @@ const int
 sqlite_affinity_code(char* t)
 {
 	if ( t == NULL )
-	    return SQLITE_NULL;
-    if (strcasecmp(t, azType[1]) == 0 || strcasecmp(t, "int") == 0)
-        return SQLITE_INTEGER;
-    if (strcasecmp(t, azType[2]) == 0)
-        return SQLITE_FLOAT;
-    if (strcasecmp(t, azType[3]) == 0)
-        return SQLITE_TEXT;
-    if (strcasecmp(t, azType[4]) == 0)
-        return SQLITE_BLOB;
-    /* if (strcasecmp(t, azType[5]) == 0)
-     * error value
-     */
-    return SQLITE_NULL;
+		return SQLITE_NULL;
+	if (strcasecmp(t, azType[1]) == 0 || strcasecmp(t, "int") == 0)
+		return SQLITE_INTEGER;
+	if (strcasecmp(t, azType[2]) == 0)
+		return SQLITE_FLOAT;
+	if (strcasecmp(t, azType[3]) == 0)
+		return SQLITE_TEXT;
+	if (strcasecmp(t, azType[4]) == 0)
+		return SQLITE_BLOB;
+	return SQLITE_NULL;
 }
 
 /*
@@ -5920,7 +5917,7 @@ conversion_error_callback(void *arg)
 			value_text = palloc (max_logged_byte_length * 2 + 1);
 			for (size_t i = 0; i < value_byte_size_blob_or_utf8; ++i)
 				sprintf(value_text + i * 2, "%02x", vt[i]);
-	    }
+		}
 
 		err_hint_mess = err_hint_mess0;
 		err_hint_mess += sprintf(

--- a/sqlite_fdw.c
+++ b/sqlite_fdw.c
@@ -5262,15 +5262,13 @@ sqlite_execute_insert(EState *estate,
 	int			nestlevel;
 	int			bindnum = 0;
 	int			i;
+	Relation	rel = resultRelInfo->ri_RelationDesc;
+	Oid			foreignTableId = RelationGetRelid(rel);
 
 #if PG_VERSION_NUM >= 140000
-	Relation	rel = resultRelInfo->ri_RelationDesc;
 	TupleDesc	tupdesc = RelationGetDescr(rel);
-	Oid			foreignTableId = RelationGetRelid(rel);
-	elog(DEBUG1, "sqlite_fdw : %s for RelId %u", __func__, foreignTableId);
-#else
-	elog(DEBUG1, "sqlite_fdw : %s", __func__);
 #endif
+	elog(DEBUG1, "sqlite_fdw : %s for RelId %u", __func__, foreignTableId);
 
 	oldcontext = MemoryContextSwitchTo(fmstate->temp_cxt);
 
@@ -5314,11 +5312,7 @@ sqlite_execute_insert(EState *estate,
 #endif
 
 			value = slot_getattr(slots[i], attnum + 1, &isnull);
-#if PG_VERSION_NUM >= 140000
 			sqlite_bind_sql_var(att, bindnum, value, fmstate->stmt, &isnull, foreignTableId);
-#else
-			sqlite_bind_sql_var(att, bindnum, value, fmstate->stmt, &isnull, InvalidOid);
-#endif
 			bindnum++;
 		}
 	}

--- a/sqlite_fdw.h
+++ b/sqlite_fdw.h
@@ -325,6 +325,7 @@ extern EquivalenceMember *sqlite_find_em_for_rel_target(PlannerInfo *root,
 /* in sqlite_fdw.c */
 extern int	sqlite_set_transmission_modes(void);
 extern void sqlite_reset_transmission_modes(int nestlevel);
+extern const int sqlite_affinity_code(char* t);
 
 /* option.c headers */
 extern sqlite_opt * sqlite_get_options(Oid foreigntableid);
@@ -387,7 +388,7 @@ extern void sqlite_do_sql_command(sqlite3 * conn, const char *sql, int level, Li
 
 void sqlite_fdw_data_norm_functs_init(sqlite3* db);
 
-/* sqlite_query.c haders */
+/* sqlite_query.c headers */
 sqlite3_int64
 			binstr2int64(const char *s);
 

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ sqlite3 "$testdir/core.db" < sql/init_data/init_core.sql;
 sqlite3 "$testdir/common.db" < sql/init_data/init.sql;
 sqlite3 "$testdir/selectfunc.db" < sql/init_data/init_selectfunc.sql;
 
-sed -i 's/REGRESS =.*/REGRESS = extra\/sqlite_fdw_post extra\/float4 extra\/float8 extra\/int4 extra\/int8 extra\/numeric extra\/out_of_range extra\/bitstring extra\/join extra\/limit extra\/aggregates extra\/prepare extra\/select_having extra\/select extra\/insert extra\/update extra\/timestamp extra\/encodings extra\/bool extra\/uuid sqlite_fdw type aggregate selectfunc /' Makefile
+sed -i 's/REGRESS =.*/REGRESS = extra\/sqlite_fdw_post extra\/bitstring extra\/bool extra\/float4 extra\/float8 extra\/int4 extra\/int8 extra\/numeric extra\/out_of_range extra\/timestamp extra\/uuid extra\/join extra\/limit extra\/aggregates extra\/prepare extra\/select_having extra\/select extra\/insert extra\/update extra\/encodings sqlite_fdw type aggregate selectfunc /' Makefile
 
 make clean;
 make $1;


### PR DESCRIPTION
In this PR
- `UPDATE` works with `column_type` option for mixed affinity cases and writes different affinity values depends on value of the option. This fix https://github.com/pgspider/sqlite_fdw/issues/90. This issue affects `uuid` and `timestamp` types of data, implemented in different time. Mixed affinity `timestamp` was implemented before `uuid` support in https://github.com/pgspider/sqlite_fdw/pull/82,
- UUID behaviour and tests are unified between all supported PostgreSQL versions for full mixed affinity support with both of `SELECT`/`WHERE` usage, `INSERT` and `UPDATE`,
- regress tests reordered: `sqlite_fdw_post` firsts, than tests about data types in ABC order, other sequence with no changes,
- add a function which converted  `column_type` option value to SQLite affinity code for standard values with `int` as `integer` affinity synonym,
- `uuid` test renumbering and add `COSTS OFF` in some TCs,
- add to `uuid` test important TC about semantics conflict in SQLite: the same UUID values with different affinity, but no error during SQLite unique check,
- add current behaviour for `Infinity` values in `floatN` column into `type` tests with SQLite unique value check. No code changes. This behaviour should be tested _before_ special planned PR about special values in `floatN` columns,
- add translation rule for `IMPORT FOREIGN SCHEMA` if SQLite formal column  name is `uuid`.