### PR TITLE
Add `NaN` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Features
 	- `timestamp`: `text` and `int`,
 	- `uuid`: `text`(32..39) and `blob`(16),
  	- `bool`: `text`(1..5) and `int`,
- 	- `double precision`, `float` and `numeric`: `real` values and special values with `text` affinity (`+Infinity` and `-Infinity`).
+ 	- `double precision`, `float` and `numeric`: `real` values and special values with `text` affinity (`+Infinity`, `-Infinity`, `NaN`).
 - Support mixed SQLite [data affinity](https://www.sqlite.org/datatype3.html) output (`INSERT`/`UPDATE`) for such data types as
 	- `timestamp`: `text`(default) or `int`,
  	- `uuid`: `text`(36) or `blob`(16)(default).
@@ -572,7 +572,7 @@ SQLite `text` affinity values which is different for SQLite unique checks can be
 - SQLite promises to preserve the 15 most significant digits of a floating point value. The big value which exceed 15 most significant digits may become different value after inserted.
 - SQLite does not support `numeric` type as PostgreSQL. Therefore, it does not allow to store numbers with too high precision and scale. Error out of range occurs.
 - SQLite does not support `NaN` special value for IEEE 754-2008 numbers. Please use this special value very cerefully because there is no such conception in SQLite at all and `NaN` value treated in SQLite as `NULL`.
-- SQLite support `+Infinity` and `-Infinity` special values for IEEE 754-2008 numbers in SQL expressions with numeric context. This values can be readed with both `text` and `real` affiniy, but can be writed to SQLite only with `real` affinity (as signed out of range value `9e999`).
+- SQLite support `+Infinity` and `-Infinity` special values for IEEE 754-2008 numbers in SQL expressions with numeric context. This values can be readed with both `text` and `real` affiniy, but can be writed to SQLite only with `real` affinity (as signed out of range value `9.0e999`).
 
 ### Boolean values
 - `sqlite_fdw` boolean values support exists only for `bool` columns in foreign table. SQLite documentation recommends to store boolean as value with `integer` [affinity](https://www.sqlite.org/datatype3.html). `NULL` isn't converted, 1 converted to `true`, all other `NOT NULL` values converted to `false`. During `SELECT ... WHERE condition_column` condition converted only to `condition_column`.

--- a/expected/12.16/extra/float4.out
+++ b/expected/12.16/extra/float4.out
@@ -1258,7 +1258,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -1303,7 +1303,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1329,7 +1330,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1354,14 +1356,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1381,13 +1385,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -1422,9 +1427,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -1474,7 +1480,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -1511,7 +1518,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -1533,9 +1541,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -1570,9 +1579,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -1638,9 +1648,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/12.16/extra/float4.out
+++ b/expected/12.16/extra/float4.out
@@ -1240,6 +1240,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1293,13 +1296,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1318,13 +1322,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1349,12 +1354,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1374,7 +1381,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1598,6 +1605,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1794,6 +1838,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/12.16/extra/float4.out
+++ b/expected/12.16/extra/float4.out
@@ -1240,7 +1240,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/expected/12.16/extra/float8.out
+++ b/expected/12.16/extra/float8.out
@@ -1657,6 +1657,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1710,13 +1713,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1735,13 +1739,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1766,12 +1771,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1791,7 +1798,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2015,6 +2022,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2211,6 +2255,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/12.16/extra/float8.out
+++ b/expected/12.16/extra/float8.out
@@ -1675,7 +1675,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -1720,7 +1720,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1746,7 +1747,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1771,14 +1773,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1798,13 +1802,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -1839,9 +1844,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -1891,7 +1897,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -1928,7 +1935,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -1950,9 +1958,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -1987,9 +1996,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -2055,9 +2065,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/12.16/extra/float8.out
+++ b/expected/12.16/extra/float8.out
@@ -1657,7 +1657,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/expected/13.12/extra/float4.out
+++ b/expected/13.12/extra/float4.out
@@ -1258,7 +1258,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -1303,7 +1303,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1329,7 +1330,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1354,14 +1356,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1381,13 +1385,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -1422,9 +1427,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -1474,7 +1480,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -1511,7 +1518,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -1533,9 +1541,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -1570,9 +1579,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -1638,9 +1648,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/13.12/extra/float4.out
+++ b/expected/13.12/extra/float4.out
@@ -1240,6 +1240,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1293,13 +1296,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1318,13 +1322,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1349,12 +1354,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1374,7 +1381,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1598,6 +1605,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1794,6 +1838,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/13.12/extra/float4.out
+++ b/expected/13.12/extra/float4.out
@@ -1240,7 +1240,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/expected/13.12/extra/float8.out
+++ b/expected/13.12/extra/float8.out
@@ -1657,6 +1657,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1710,13 +1713,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1735,13 +1739,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1766,12 +1771,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1791,7 +1798,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2015,6 +2022,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2211,6 +2255,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/13.12/extra/float8.out
+++ b/expected/13.12/extra/float8.out
@@ -1675,7 +1675,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -1720,7 +1720,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1746,7 +1747,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1771,14 +1773,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1798,13 +1802,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -1839,9 +1844,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -1891,7 +1897,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -1928,7 +1935,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -1950,9 +1958,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -1987,9 +1996,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -2055,9 +2065,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/13.12/extra/float8.out
+++ b/expected/13.12/extra/float8.out
@@ -1657,7 +1657,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/expected/14.9/extra/float4.out
+++ b/expected/14.9/extra/float4.out
@@ -1262,7 +1262,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/expected/14.9/extra/float4.out
+++ b/expected/14.9/extra/float4.out
@@ -1280,7 +1280,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -1325,7 +1325,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1351,7 +1352,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1376,14 +1378,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1403,13 +1407,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -1444,9 +1449,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -1496,7 +1502,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -1533,7 +1540,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -1555,9 +1563,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -1592,9 +1601,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -1660,9 +1670,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/14.9/extra/float4.out
+++ b/expected/14.9/extra/float4.out
@@ -1262,6 +1262,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1315,13 +1318,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1340,13 +1344,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1371,12 +1376,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1396,7 +1403,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1620,6 +1627,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1816,6 +1860,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/14.9/extra/float8.out
+++ b/expected/14.9/extra/float8.out
@@ -1986,7 +1986,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/expected/14.9/extra/float8.out
+++ b/expected/14.9/extra/float8.out
@@ -1986,6 +1986,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -2039,13 +2042,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -2064,13 +2068,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -2095,12 +2100,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -2120,7 +2127,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2344,6 +2351,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2540,6 +2584,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/14.9/extra/float8.out
+++ b/expected/14.9/extra/float8.out
@@ -2004,7 +2004,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -2049,7 +2049,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -2075,7 +2076,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -2100,14 +2102,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -2127,13 +2131,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -2168,9 +2173,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -2220,7 +2226,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -2257,7 +2264,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -2279,9 +2287,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -2316,9 +2325,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -2384,9 +2394,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/15.4/extra/float4.out
+++ b/expected/15.4/extra/float4.out
@@ -1262,7 +1262,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/expected/15.4/extra/float4.out
+++ b/expected/15.4/extra/float4.out
@@ -1280,7 +1280,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -1325,7 +1325,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1351,7 +1352,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1376,14 +1378,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1403,13 +1407,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -1444,9 +1449,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -1496,7 +1502,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -1533,7 +1540,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -1555,9 +1563,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -1592,9 +1601,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -1660,9 +1670,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/15.4/extra/float4.out
+++ b/expected/15.4/extra/float4.out
@@ -1262,6 +1262,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1315,13 +1318,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1340,13 +1344,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1371,12 +1376,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1396,7 +1403,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1620,6 +1627,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1816,6 +1860,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/15.4/extra/float8.out
+++ b/expected/15.4/extra/float8.out
@@ -1986,7 +1986,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/expected/15.4/extra/float8.out
+++ b/expected/15.4/extra/float8.out
@@ -1986,6 +1986,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -2039,13 +2042,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -2064,13 +2068,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -2095,12 +2100,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -2120,7 +2127,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2344,6 +2351,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2540,6 +2584,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/15.4/extra/float8.out
+++ b/expected/15.4/extra/float8.out
@@ -2004,7 +2004,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -2049,7 +2049,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -2075,7 +2076,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -2100,14 +2102,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -2127,13 +2131,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -2168,9 +2173,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -2220,7 +2226,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -2257,7 +2264,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -2279,9 +2287,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -2316,9 +2325,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -2384,9 +2394,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/16.0/extra/float4.out
+++ b/expected/16.0/extra/float4.out
@@ -1307,7 +1307,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -1352,7 +1352,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1378,7 +1379,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1403,14 +1405,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1430,13 +1434,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -1471,9 +1476,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -1523,7 +1529,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -1560,7 +1567,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -1582,9 +1590,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -1619,9 +1628,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -1687,9 +1697,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/16.0/extra/float4.out
+++ b/expected/16.0/extra/float4.out
@@ -1289,6 +1289,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1342,13 +1345,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -1367,13 +1371,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -1398,12 +1403,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -1423,7 +1430,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1647,6 +1654,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -1843,6 +1887,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/16.0/extra/float4.out
+++ b/expected/16.0/extra/float4.out
@@ -1289,7 +1289,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/expected/16.0/extra/float8.out
+++ b/expected/16.0/extra/float8.out
@@ -2072,7 +2072,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:
@@ -2117,7 +2117,8 @@ SELECT * FROM "type_FLOAT_INF";
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(20 rows)
+ 23 |       NaN
+(21 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -2143,7 +2144,8 @@ SELECT * FROM "type_FLOAT_INF+";
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(20 rows)
+ 23 |       NaN | text | 3
+(21 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -2168,14 +2170,16 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
+ 23 |       NaN | text | 3
  16 |           | null |  
-(20 rows)
+(21 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
  16 |           | null |  
+ 23 |       NaN | text | 3
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -2195,13 +2199,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(20 rows)
+(21 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 310:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Infinity' ORDER BY i;
@@ -2236,9 +2241,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '+Infinity' ORDER BY i;
 
 --Testcase 312:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 313:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '+Inf' ORDER BY i;
@@ -2288,7 +2294,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Infinity' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 316:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Infinity' ORDER BY i;
@@ -2325,7 +2332,8 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > '-Inf' ORDER BY i;
  18 | Infinity | text | 9
  20 | Infinity | text | 3
  21 | Infinity | text | 4
-(13 rows)
+ 23 |      NaN | text | 3
+(14 rows)
 
 --Testcase 319:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < '-Inf' ORDER BY i;
@@ -2347,9 +2355,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = '-Inf' ORDER BY i;
 
 --Testcase 321:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Infinity' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 322:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Infinity' ORDER BY i;
@@ -2384,9 +2393,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Infinity' ORDER BY i;
 
 --Testcase 324:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 325:
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
@@ -2452,9 +2462,10 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
 
 --Testcase 329:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
- i | f | t | l 
----+---+---+---
-(0 rows)
+ i  |  f  |  t   | l 
+----+-----+------+---
+ 23 | NaN | text | 3
+(1 row)
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/expected/16.0/extra/float8.out
+++ b/expected/16.0/extra/float8.out
@@ -2054,6 +2054,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -2107,13 +2110,14 @@ SELECT * FROM "type_FLOAT_INF";
  13 |  Infinity
  14 |  Infinity
  15 | -Infinity
+ 16 |          
  17 |  Infinity
  18 |  Infinity
  19 | -Infinity
  20 |  Infinity
  21 |  Infinity
  22 | -Infinity
-(19 rows)
+(20 rows)
 
 --Testcase 306:
 SELECT * FROM "type_FLOAT_INF+";
@@ -2132,13 +2136,14 @@ SELECT * FROM "type_FLOAT_INF+";
  13 |  Infinity | real | 3
  14 |  Infinity | real | 3
  15 | -Infinity | real | 4
+ 16 |           | null |  
  17 |  Infinity | text | 8
  18 |  Infinity | text | 9
  19 | -Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 307:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
@@ -2163,12 +2168,14 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f ASC, i;
  18 |  Infinity | text | 9
  20 |  Infinity | text | 3
  21 |  Infinity | text | 4
-(19 rows)
+ 16 |           | null |  
+(20 rows)
 
 --Testcase 308:
 SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  i  |     f     |  t   | l 
 ----+-----------+------+---
+ 16 |           | null |  
   2 |  Infinity | real | 3
   4 |  Infinity | real | 3
  10 |  Infinity | real | 3
@@ -2188,7 +2195,7 @@ SELECT * FROM "type_FLOAT_INF+" ORDER BY f DESC, i;
  15 | -Infinity | real | 4
  19 | -Infinity | text | 9
  22 | -Infinity | text | 4
-(19 rows)
+(20 rows)
 
 --Testcase 309:
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2412,6 +2419,43 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
  21 | Infinity | text | 4
 (10 rows)
 
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+ i  |     f     |  t   | l 
+----+-----------+------+---
+  1 | -Infinity | real | 4
+  2 |  Infinity | real | 3
+  3 | -Infinity | real | 4
+  4 |  Infinity | real | 3
+  5 |   -1e+308 | real | 9
+  6 |         0 | real | 3
+  7 |    1e+308 | real | 8
+ 10 |  Infinity | real | 3
+ 11 |  Infinity | real | 3
+ 12 | -Infinity | real | 4
+ 13 |  Infinity | real | 3
+ 14 |  Infinity | real | 3
+ 15 | -Infinity | real | 4
+ 17 |  Infinity | text | 8
+ 18 |  Infinity | text | 9
+ 19 | -Infinity | text | 9
+ 20 |  Infinity | text | 3
+ 21 |  Infinity | text | 4
+ 22 | -Infinity | text | 4
+(19 rows)
+
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+ i | f | t | l 
+---+---+---+---
+(0 rows)
+
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f > '+Infinity' ORDER BY i;
@@ -2608,6 +2652,39 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
    ->  Foreign Scan on public."type_FLOAT_INF+"
          Output: i, f, t, l
          SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 9e999))
+(6 rows)
+
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) > 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+                                                                         QUERY PLAN                                                                          
+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan on public."type_FLOAT_INF+"
+   Output: i, f, t, l
+   SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) < 'NaN')) ORDER BY `i` ASC NULLS LAST
+(3 rows)
+
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: i, f, t, l
+   Sort Key: "type_FLOAT_INF+".i
+   ->  Foreign Scan on public."type_FLOAT_INF+"
+         Output: i, f, t, l
+         SQLite query: SELECT `i`, sqlite_fdw_float(`f`), `t`, `l` FROM main."type_FLOAT_INF+" WHERE ((sqlite_fdw_float(`f`) = 'NaN'))
 (6 rows)
 
 --Testcase 351:

--- a/expected/16.0/extra/float8.out
+++ b/expected/16.0/extra/float8.out
@@ -2054,7 +2054,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/12.16/extra/float4.sql
+++ b/sql/12.16/extra/float4.sql
@@ -676,6 +676,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -750,6 +753,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -805,7 +814,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/12.16/extra/float4.sql
+++ b/sql/12.16/extra/float4.sql
@@ -676,7 +676,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/12.16/extra/float4.sql
+++ b/sql/12.16/extra/float4.sql
@@ -694,7 +694,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/12.16/extra/float8.sql
+++ b/sql/12.16/extra/float8.sql
@@ -922,6 +922,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -996,6 +999,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1051,7 +1060,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/12.16/extra/float8.sql
+++ b/sql/12.16/extra/float8.sql
@@ -922,7 +922,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/12.16/extra/float8.sql
+++ b/sql/12.16/extra/float8.sql
@@ -940,7 +940,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/13.12/extra/float4.sql
+++ b/sql/13.12/extra/float4.sql
@@ -676,6 +676,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -750,6 +753,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -805,7 +814,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/13.12/extra/float4.sql
+++ b/sql/13.12/extra/float4.sql
@@ -676,7 +676,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/13.12/extra/float4.sql
+++ b/sql/13.12/extra/float4.sql
@@ -694,7 +694,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/13.12/extra/float8.sql
+++ b/sql/13.12/extra/float8.sql
@@ -922,6 +922,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -996,6 +999,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1051,7 +1060,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/13.12/extra/float8.sql
+++ b/sql/13.12/extra/float8.sql
@@ -922,7 +922,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/13.12/extra/float8.sql
+++ b/sql/13.12/extra/float8.sql
@@ -940,7 +940,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/14.9/extra/float4.sql
+++ b/sql/14.9/extra/float4.sql
@@ -688,6 +688,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -762,6 +765,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -817,7 +826,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/14.9/extra/float4.sql
+++ b/sql/14.9/extra/float4.sql
@@ -688,7 +688,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/14.9/extra/float4.sql
+++ b/sql/14.9/extra/float4.sql
@@ -706,7 +706,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/14.9/extra/float8.sql
+++ b/sql/14.9/extra/float8.sql
@@ -1127,7 +1127,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/14.9/extra/float8.sql
+++ b/sql/14.9/extra/float8.sql
@@ -1109,7 +1109,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/14.9/extra/float8.sql
+++ b/sql/14.9/extra/float8.sql
@@ -1109,6 +1109,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1183,6 +1186,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1238,7 +1247,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/15.4/extra/float4.sql
+++ b/sql/15.4/extra/float4.sql
@@ -688,6 +688,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -762,6 +765,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -817,7 +826,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/15.4/extra/float4.sql
+++ b/sql/15.4/extra/float4.sql
@@ -688,7 +688,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/15.4/extra/float4.sql
+++ b/sql/15.4/extra/float4.sql
@@ -706,7 +706,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/15.4/extra/float8.sql
+++ b/sql/15.4/extra/float8.sql
@@ -1127,7 +1127,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/15.4/extra/float8.sql
+++ b/sql/15.4/extra/float8.sql
@@ -1109,7 +1109,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/15.4/extra/float8.sql
+++ b/sql/15.4/extra/float8.sql
@@ -1109,6 +1109,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1183,6 +1186,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1238,7 +1247,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/16.0/extra/float4.sql
+++ b/sql/16.0/extra/float4.sql
@@ -715,7 +715,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/16.0/extra/float4.sql
+++ b/sql/16.0/extra/float4.sql
@@ -697,7 +697,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sql/16.0/extra/float4.sql
+++ b/sql/16.0/extra/float4.sql
@@ -697,6 +697,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -771,6 +774,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -826,7 +835,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/16.0/extra/float8.sql
+++ b/sql/16.0/extra/float8.sql
@@ -1134,6 +1134,9 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
+--Testcase 289: Inserted as NULL!!!
+--see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:
 ALTER FOREIGN TABLE "type_FLOAT_INF" ALTER COLUMN "f" TYPE text;
 --Testcase 291:
@@ -1208,6 +1211,12 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f > 'Inf' ORDER BY i;
 SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 326:
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
+--Testcase 327:
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 328:
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 329:
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 330:
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -1263,7 +1272,15 @@ SELECT * FROM "type_FLOAT_INF+" WHERE f < 'Inf' ORDER BY i;
 --Testcase 347:
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT * FROM "type_FLOAT_INF+" WHERE f = 'Inf' ORDER BY i;
-
+--Testcase 348:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f > 'NaN' ORDER BY i;
+--Testcase 349:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f < 'NaN' ORDER BY i;
+--Testcase 350:
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT * FROM "type_FLOAT_INF+" WHERE f = 'NaN' ORDER BY i;
 
 --Testcase 351:
 DELETE FROM "type_FLOAT_INF" WHERE i >= 10;

--- a/sql/16.0/extra/float8.sql
+++ b/sql/16.0/extra/float8.sql
@@ -1152,7 +1152,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (21, '+Inf');
 --Testcase 296:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (22, '-Inf');
 --Testcase 297:
---INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
+INSERT INTO "type_FLOAT_INF" (i, f) VALUES (23, 'NaN');
 --Testcase 298:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (24, 'Infinity__');
 --Testcase 299:

--- a/sql/16.0/extra/float8.sql
+++ b/sql/16.0/extra/float8.sql
@@ -1134,7 +1134,7 @@ INSERT INTO "type_FLOAT_INF" (i, f) VALUES (13, 'Inf');
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (14, '+Inf');
 --Testcase 288:
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (15, '-Inf');
---Testcase 289: Inserted as NULL!!!
+--Testcase 289: SQLite ignores NaN
 --see https://github.com/sqlite/sqlite/blob/6db0b11e078f4b651f0cf00f845f3d77700c1a3a/src/vdbemem.c#L973
 INSERT INTO "type_FLOAT_INF" (i, f) VALUES (16, 'NaN');
 --Testcase 290:

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -228,12 +228,6 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 							Datum		d = DirectFunctionCall1(dtof, Float8GetDatum((float8)value));
 							return (struct NullableDatum) {d, false};
 						}
-					case SQLITE_INTEGER:
-					case SQLITE_BLOB:
-						{
-							sqlite_value_to_pg_error();
-							break;
-						}
 					case SQLITE3_TEXT:
 						{
 							if (value_byte_size_blob_or_utf8)
@@ -248,6 +242,8 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 								pg_column_void_text_error();
 							break;
 						}
+					case SQLITE_INTEGER:
+					case SQLITE_BLOB:
 					default:
 						{
 							sqlite_value_to_pg_error();
@@ -265,12 +261,6 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 							double		value = sqlite3_value_double(val);
 							return (struct NullableDatum) {Float8GetDatum((float8) value), false};
 						}
-					case SQLITE_INTEGER:
-					case SQLITE_BLOB:
-						{
-							sqlite_value_to_pg_error();
-							break;
-						}
 					case SQLITE3_TEXT:
 						{
 							if (value_byte_size_blob_or_utf8)
@@ -285,6 +275,8 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 								pg_column_void_text_error();
 							break;
 						}
+					case SQLITE_INTEGER:
+					case SQLITE_BLOB:
 					default:
 						{
 							sqlite_value_to_pg_error();

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -230,25 +230,25 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 						}
 					case SQLITE_INTEGER:
 					case SQLITE_BLOB:
+					case SQLITE3_TEXT:
+						{
+							if (value_byte_size_blob_or_utf8)
+							{
+								const char* text_value = (const char*) sqlite3_value_text(val);
+								if (strcasecmp(text_value, "NaN") == 0)
+									return (struct NullableDatum) {Float8GetDatum(NAN), false};
+								else
+									sqlite_value_to_pg_error();
+				 			}
+							else
+								pg_column_void_text_error();
+							break;
+						}
 					default:
 						{
 							sqlite_value_to_pg_error();
 							break;
 						}
-					case SQLITE3_TEXT:
-					{
-						if (value_byte_size_blob_or_utf8)
-						{
-							const char* text_value = (const char*) sqlite3_value_text(val);
-							if (strcasecmp(text_value, "NaN") == 0)
-								return (struct NullableDatum) {Float8GetDatum(NAN), false};
-							else
-								sqlite_value_to_pg_error();
-			 			}
-						else
-							pg_column_void_text_error();
-						break;
-					}
 				}
 				break;
 			}
@@ -263,25 +263,25 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 						}
 					case SQLITE_INTEGER:
 					case SQLITE_BLOB:
+					case SQLITE3_TEXT:
+						{
+							if (value_byte_size_blob_or_utf8)
+							{
+								const char* text_value = (const char*) sqlite3_value_text(val);
+								if (strcasecmp(text_value, "NaN") == 0)
+									return (struct NullableDatum) {Float8GetDatum(NAN), false};
+								else
+									sqlite_value_to_pg_error();
+				 			}
+							else
+								pg_column_void_text_error();
+							break;
+						}
 					default:
 						{
 							sqlite_value_to_pg_error();
 							break;
 						}
-					case SQLITE3_TEXT:
-					{
-						if (value_byte_size_blob_or_utf8)
-						{
-							const char* text_value = (const char*) sqlite3_value_text(val);
-							if (strcasecmp(text_value, "NaN") == 0)
-								return (struct NullableDatum) {Float8GetDatum(NAN), false};
-							else
-								sqlite_value_to_pg_error();
-			 			}
-						else
-							pg_column_void_text_error();
-						break;
-					}
 				}
 				break;
 			}

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -239,7 +239,11 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 					{
 						if (value_byte_size_blob_or_utf8)
 						{
-		 					sqlite_value_to_pg_error();
+							const char* text_value = (const char*) sqlite3_value_text(val);
+							if (strcasecmp(text_value, "NaN") == 0)
+								return (struct NullableDatum) {Float8GetDatum(NAN), false};
+							else
+								sqlite_value_to_pg_error();
 			 			}
 						else
 							pg_column_void_text_error();
@@ -268,7 +272,11 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 					{
 						if (value_byte_size_blob_or_utf8)
 						{
-		 					sqlite_value_to_pg_error();
+							const char* text_value = (const char*) sqlite3_value_text(val);
+							if (strcasecmp(text_value, "NaN") == 0)
+								return (struct NullableDatum) {Float8GetDatum(NAN), false};
+							else
+								sqlite_value_to_pg_error();
 			 			}
 						else
 							pg_column_void_text_error();
@@ -343,7 +351,11 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 					{
 						if (value_byte_size_blob_or_utf8)
 						{
-		 					sqlite_value_to_pg_error();
+							const char* text_value = (const char*) sqlite3_value_text(val);
+							if (strcasecmp(text_value, "NaN") == 0)
+								return (struct NullableDatum) {Float8GetDatum(NAN), false};
+							else
+								sqlite_value_to_pg_error();
 			 			}
 						else
 							pg_column_void_text_error();

--- a/sqlite_query.c
+++ b/sqlite_query.c
@@ -230,6 +230,10 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 						}
 					case SQLITE_INTEGER:
 					case SQLITE_BLOB:
+						{
+							sqlite_value_to_pg_error();
+							break;
+						}
 					case SQLITE3_TEXT:
 						{
 							if (value_byte_size_blob_or_utf8)
@@ -263,6 +267,10 @@ sqlite_convert_to_pg(Form_pg_attribute att, sqlite3_value * val, AttInMetadata *
 						}
 					case SQLITE_INTEGER:
 					case SQLITE_BLOB:
+						{
+							sqlite_value_to_pg_error();
+							break;
+						}
 					case SQLITE3_TEXT:
 						{
 							if (value_byte_size_blob_or_utf8)


### PR DESCRIPTION
This implementation methodologically bases on

- ISO:SQL
- https://github.com/pgspider/sqlite_fdw/issues/36
- https://github.com/pgspider/sqlite_fdw/issues/66
- SQLite [`NaN` ignore code](https://github.com/sqlite/sqlite/blob/7da33383c7952e88b6ded2b684d12545b93caca0/src/vdbemem.c#L980-L982)

This PR implements `NaN` as readable value from SQLite if there is such case insensitive value with `text` affinity.

According ISO:SQL and implemented PostgreSQL code we can input `NaN` as special IEEE-754 value through API or as special text constant through SQL. SQLite doesn't support `NaN` with `real` affinity (in opposition to ±∞ values) and [doesn't rewrites `NULL` value if `NaN` is detected](https://github.com/sqlite/sqlite/blob/7da33383c7952e88b6ded2b684d12545b93caca0/src/vdbemem.c#L980-L982). Hence in this PR `NaN` is _readable_ and _detectable_ but **not writeable**.

About changes:

- `NaN` implementation was untested outside of [`aggregates`](https://github.com/pgspider/sqlite_fdw/blob/master/sql/16.0/extra/aggregates.sql) test, https://github.com/pgspider/sqlite_fdw/commit/70f2f36e9cf6006ec3b5db89a7d477621f385298 adds tests for previous implementation,
- https://github.com/pgspider/sqlite_fdw/commit/026d6efbd584bf03b65fdad195469e43a5ffca5b adds support for readable `NaN` value with `text` affinity in SQLite.